### PR TITLE
Url encode branch and tag names

### DIFF
--- a/src/test/java/com/cloudogu/scmmanager/scm/api/ScmManagerApiTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/scm/api/ScmManagerApiTest.java
@@ -124,6 +124,20 @@ public class ScmManagerApiTest extends ApiClientTestBase {
   }
 
   @Test
+  public void shouldLoadSingleBranchWithSlashInName() throws ExecutionException, InterruptedException {
+    ScmManagerApi api = new ScmManagerApi(apiClient());
+
+    Repository repository = Mockito.mock(Repository.class);
+    when(repository.getLinks()).thenReturn(linkingTo().single(link("branches", "/scm/api/v2/repositories/jenkins-plugin/hello-shell/branches/")).build());
+    CloneInformation cloneInformation = new CloneInformation("git", "http://hitchhiker.com/");
+    when(repository.getCloneInformation()).thenReturn(cloneInformation);
+
+    Branch branch = api.getBranch(repository, "feature/readme").get();
+    assertThat(branch.getName()).isEqualTo("feature/readme");
+    assertThat(branch.getRevision()).isEqualTo("1d56c86c55170e71e16bc3bba82bb28e9328ce47");
+  }
+
+  @Test
   public void shouldLoadPullRequests() throws ExecutionException, InterruptedException {
     ScmManagerApi api = new ScmManagerApi(apiClient());
 

--- a/src/test/resources/mappings/branchFeatureReadme.json
+++ b/src/test/resources/mappings/branchFeatureReadme.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "url": "/scm/api/v2/repositories/jenkins-plugin/hello-shell/branches/feature%2Freadme",
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.scmm-branch+json;v=2"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "body": "{\"name\":\"feature/readme\",\"revision\":\"1d56c86c55170e71e16bc3bba82bb28e9328ce47\",\"defaultBranch\":false,\"_links\":{\"self\":{\"href\":\"/scm/api/v2/repositories/jenkins-plugin/hello-shell/branches/feature%2Freadme\"},\"history\":{\"href\":\"/scm/api/v2/repositories/jenkins-plugin/hello-shell/branches/feature%2Freadme/changesets/\"},\"changeset\":{\"href\":\"/scm/api/v2/repositories/jenkins-plugin/hello-shell/changesets/6f6ea59a8c504f2c9f3cd93c02e289aa8b65e9c3\"},\"source\":{\"href\":\"/scm/api/v2/repositories/jenkins-plugin/hello-shell/sources/6f6ea59a8c504f2c9f3cd93c02e289aa8b65e9c3\"}}}",
+    "headers": {
+      "Content-Type": "application/vnd.scmm-branch+json;v=2"
+    }
+  }
+}


### PR DESCRIPTION
Fixes missing url encoding for branch and tag names in the api client.