### PR TITLE
Do not handle return status 302 as an error

### DIFF
--- a/src/main/java/com/cloudogu/scmmanager/scm/ScmManagerSourceDescriptor.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/ScmManagerSourceDescriptor.java
@@ -5,6 +5,7 @@ import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.cloudogu.scmmanager.HttpAuthentication;
 import com.cloudogu.scmmanager.scm.api.Authentications;
+import com.cloudogu.scmmanager.scm.api.IllegalReturnStatusException;
 import com.cloudogu.scmmanager.scm.api.Repository;
 import com.cloudogu.scmmanager.scm.api.ScmManagerApi;
 import com.google.common.annotations.VisibleForTesting;
@@ -72,7 +73,12 @@ public class ScmManagerSourceDescriptor extends SCMSourceDescriptor {
         }
         return FormValidation.error("api has no login link");
       })
-      .exceptionally(e -> FormValidation.error(e.getMessage()))
+      .exceptionally(e -> {
+        if (e.getCause() instanceof IllegalReturnStatusException && ((IllegalReturnStatusException) e.getCause()).getStatusCode() == 302) {
+          return FormValidation.ok("Credentials needed");
+        }
+        return FormValidation.error(e.getMessage());
+      })
       .get();
   }
 

--- a/src/test/java/com/cloudogu/scmmanager/scm/ScmManagerApiTestMocks.java
+++ b/src/test/java/com/cloudogu/scmmanager/scm/ScmManagerApiTestMocks.java
@@ -1,6 +1,5 @@
 package com.cloudogu.scmmanager.scm;
 
-import com.cloudogu.scmmanager.scm.api.ApiClient;
 import org.mockito.stubbing.OngoingStubbing;
 
 import java.util.Arrays;
@@ -11,7 +10,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class ScmManagerApiTestMocks {
 


### PR DESCRIPTION
If SCM-Manager is run behind a CAS (like, for example in a
Cloudogu EcoSystem), the index cannot be queried without
proper credentials. In this case we will ignore the redirect
to CAS and wait until credentials are specified.