### PR TITLE
Use MergeWithGitSCMExtension instead of PreBuildMerge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>3.4.0</version>
+      <version>3.5.0</version>
       <optional>true</optional>
     </dependency>
 


### PR DESCRIPTION
We use now MergeWithGitSCMExtension for the pre build merge of pull request heads, because this extension is made for the use in ScmSource implementations.
The extension will configure a git user and an email for the merge commit, this should fix pull request builds on nodes without git config.