### PR TITLE
Fix wrong CHANGE_BRANCH environment variable of pr builds

### DIFF
--- a/src/main/java/com/cloudogu/scmmanager/scm/api/ScmManagerPullRequestHead.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/api/ScmManagerPullRequestHead.java
@@ -47,7 +47,7 @@ public class ScmManagerPullRequestHead extends ScmManagerHead implements ChangeR
   @NonNull
   @Override
   public String getOriginName() {
-    return getTarget().getName();
+    return getSource().getName();
   }
 
   @NonNull


### PR DESCRIPTION
At the moment the `CHANGE_BRANCH` and `CHANGE_TARGET` environment variables of pr builds are equal. Both point to the target branch of the pull request. This pr fixes this and let the `CHANGE_BRANCH` environment variable point to the source branch of the pr.