### PR TITLE
Handle unsuitable credentials on connection change

### DIFF
--- a/src/main/java/com/cloudogu/scmmanager/scm/ConnectionConfiguration.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/ConnectionConfiguration.java
@@ -1,5 +1,6 @@
 package com.cloudogu.scmmanager.scm;
 
+import com.cloudbees.plugins.credentials.CredentialsUnavailableException;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
@@ -55,7 +56,12 @@ class ConnectionConfiguration {
     if (Strings.isNullOrEmpty(value)) {
       return FormValidation.error("credentials are required");
     }
-    ScmManagerApi client = apiFactory.create(context, serverUrl, value);
+    ScmManagerApi client;
+    try {
+      client = apiFactory.create(context, serverUrl, value);
+    } catch (CredentialsUnavailableException e) {
+      return FormValidation.error("credentials not valid for connection type");
+    }
     CompletableFuture<HalRepresentation> future = client.index();
     return future
       .thenApply(index -> {

--- a/src/main/java/com/cloudogu/scmmanager/scm/api/CredentialsLookup.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/api/CredentialsLookup.java
@@ -26,7 +26,8 @@ class CredentialsLookup {
   public StandardUsernamePasswordCredentials http(SCMSourceOwner owner, String serverUrl, String credentialsId) {
     if (!serverUrl.startsWith("http")) {
       throw new IllegalArgumentException(String.format("http url is required, received %s instead", serverUrl));
-    }    return lookup(StandardUsernamePasswordCredentials.class, owner, serverUrl, credentialsId);
+    }
+    return lookup(StandardUsernamePasswordCredentials.class, owner, serverUrl, credentialsId);
   }
 
   private static <C extends com.cloudbees.plugins.credentials.Credentials> C lookup(Class<C> credentialsType, SCMSourceOwner owner, String serverUrl, String credentialsId) {


### PR DESCRIPTION
When the connection string is changed from an ssh to an
http connection, for a short time we may have a ssh
only credential (like pk) selected. This does not work
for http connections and therefore throws an exception.
In this fix we catch this exception and handle it.