### PR TITLE
Encode revisions in URLs

### DIFF
--- a/src/main/java/com/cloudogu/scmmanager/ScmV2Notifier.java
+++ b/src/main/java/com/cloudogu/scmmanager/ScmV2Notifier.java
@@ -114,7 +114,7 @@ public class ScmV2Notifier implements Notifier {
       namespaceAndName.getName(),
       revision,
       buildStatus.getType(),
-      URLEncoder.encode(buildStatus.getName(), "UTF-8")
+      URLEncoder.encode(buildStatus.getName(), StandardCharsets.UTF_8.name())
     );
   }
 

--- a/src/main/java/com/cloudogu/scmmanager/scm/LinkBuilder.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/LinkBuilder.java
@@ -10,6 +10,9 @@ import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 
 import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 public class LinkBuilder implements Serializable {
 
@@ -52,9 +55,19 @@ public class LinkBuilder implements Serializable {
     if (head instanceof ScmManagerPullRequestHead) {
       return concat(url, "pull-request", ((ScmManagerPullRequestHead) head).getId());
     } else if (head instanceof ScmManagerHead) {
-      return sources(head.getName());
+      String encode = encodeForUrl(head);
+      return sources(encode);
     } else {
       throw new IllegalArgumentException("unknown type of head " + head);
+    }
+  }
+
+  @SuppressWarnings("java:S112") // The exception caught here can never be thrown
+  private String encodeForUrl(SCMHead head) {
+    try {
+      return URLEncoder.encode(head.getName(), StandardCharsets.UTF_8.name());
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException(e); // this should not happen because we use StandardCharsets
     }
   }
 

--- a/src/test/java/com/cloudogu/scmmanager/scm/LinkBuilderTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/scm/LinkBuilderTest.java
@@ -41,6 +41,12 @@ public class LinkBuilderTest {
   }
 
   @Test
+  public void shouldEscapeBranchNameInLink() {
+    String link = builder.create(branch("feature/some/nice/one"));
+    assertThat(link).isEqualTo(PREFIX + "/code/sources/feature%2Fsome%2Fnice%2Fone");
+  }
+
+  @Test
   public void shouldCreateTagLink() {
     String link = builder.create(tag("42.0"));
     assertThat(link).isEqualTo(PREFIX + "/code/sources/42.0");


### PR DESCRIPTION
To create correct links to SCM-Manager we have to encode
revisions like branches or tags correctly, because they can
contain slashes or other path relevant characters so that they
do not lead to an invalid URL