### PR TITLE
JobDSL support for SCM-Manager Navigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,34 @@ credentials. This plugin will then load a list of all available namespaces you c
 Finally you can select behaviours where you can choose for example, whether branches, tags or pull requests shall be
 build.
 
+#### JobDSL
+
+In order to create a build job for an SCM-Manager namespace with the job dsl, have a look at following example:
+
+```groovy
+organizationFolder("spaceships") {
+  organizations {
+    scmManagerNamespace {
+      serverUrl('https://scm.hitchhiker.com')
+      credentialsId('my-secret-id')
+      namespace("spaceships")
+      discoverBranches(true)
+      discoverPullRequest(true)
+      discoverTags(false)
+      discoverSvn {
+        includes("trunk,branches/*,tags/*,sandbox/*")
+        excludes("")
+      }
+    }
+  }
+}
+// scan namespace directly after creation
+queue("spaceships")
+```
+
+The `discover*` parameters are optional, the example above shows the default values. 
+To disable subversion build, a `false` can be passed to the `discoverSvn` method e.g.: `discoverSvn(false)`.
+
 ### Navigation
 In different pages of Jenkins you can find links to the corresponding SCM-Manager page:
 

--- a/docs/de/index.md
+++ b/docs/de/index.md
@@ -104,6 +104,34 @@ gewählt werden. Das Plugin lädt daraufhin alle verfügbaren Namespaces, von de
 Abschließend können verschiedene Verhaltensweise gewählt und konfiguriert werden, wie z. B. ob Branches, Tags oder
 Pull Requests gebaut werden sollen.
 
+#### JobDSL
+
+Das folgende Beispiel zeigt die JobDSL, um einen Job für einen SCM-Manager Namespace zu erstellen:
+
+```groovy
+organizationFolder("spaceships") {
+  organizations {
+    scmManagerNamespace {
+      serverUrl('https://scm.hitchhiker.com')
+      credentialsId('my-secret-id')
+      namespace("spaceships")
+      discoverBranches(true)
+      discoverPullRequest(true)
+      discoverTags(false)
+      discoverSvn {
+        includes("trunk,branches/*,tags/*,sandbox/*")
+        excludes("")
+      }
+    }
+  }
+}
+// scan namespace directly after creation
+queue("spaceships")
+```
+Die `discover*` Parameter sind Optional und das Beispiel zeigt die Standardwerte.
+Um Subversion Builds zu deaktivieren, kann der `discoverSvn` Methode ein `false` übergeben werden: `discoverSvn(false)`.
+The `discover*` parameters are optional, the example above shows the default values. 
+
 ### Navigation
 Auf verschiedenen Seiten von Jenkins befinden sich Links zu entsprechenden Seiten im SCM-Manager:
 

--- a/src/main/java/com/cloudogu/scmmanager/scm/jobdsl/BranchSourceContext.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/jobdsl/BranchSourceContext.java
@@ -1,15 +1,12 @@
 package com.cloudogu.scmmanager.scm.jobdsl;
 
 import com.google.common.base.Strings;
-import javaposse.jobdsl.dsl.Context;
 import javaposse.jobdsl.dsl.Preconditions;
 
-public class BranchSourceContext implements Context {
+public class BranchSourceContext extends ScmManagerContext {
 
   private String id;
-  private String serverUrl;
   private String repository;
-  private String credentialsId;
 
   public String getId() {
     return id;
@@ -17,14 +14,6 @@ public class BranchSourceContext implements Context {
 
   public void id(String id) {
     this.id = id;
-  }
-
-  public String getServerUrl() {
-    return serverUrl;
-  }
-
-  public void serverUrl(String serverUrl) {
-    this.serverUrl = serverUrl;
   }
 
   public String getRepository() {
@@ -35,18 +24,10 @@ public class BranchSourceContext implements Context {
     this.repository = repository;
   }
 
-  public String getCredentialsId() {
-    return credentialsId;
-  }
-
-  public void credentialsId(String credentialsId) {
-    this.credentialsId = credentialsId;
-  }
-
   public void validate() {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "id is required");
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(serverUrl), "serverUrl is required");
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(repository), "serverUrl is required");
+    super.validate();
+    Preconditions.checkNotNullOrEmpty(id, "id is required");
+    Preconditions.checkNotNullOrEmpty(repository, "repository is required");
   }
 
 }

--- a/src/main/java/com/cloudogu/scmmanager/scm/jobdsl/Executor.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/jobdsl/Executor.java
@@ -1,0 +1,8 @@
+package com.cloudogu.scmmanager.scm.jobdsl;
+
+import javaposse.jobdsl.dsl.Context;
+
+@FunctionalInterface
+interface Executor {
+  void executeInContext(Runnable runnable, Context context);
+}

--- a/src/main/java/com/cloudogu/scmmanager/scm/jobdsl/JobDSL.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/jobdsl/JobDSL.java
@@ -1,0 +1,21 @@
+package com.cloudogu.scmmanager.scm.jobdsl;
+
+import com.cloudogu.scmmanager.scm.api.ScmManagerApi;
+import com.cloudogu.scmmanager.scm.api.ScmManagerApiFactory;
+import jenkins.model.Jenkins;
+
+public final class JobDSL {
+
+  private JobDSL() {
+  }
+
+  public static <C extends ScmManagerContext> C resolve(Executor executor, Runnable closure, C context) {
+    executor.executeInContext(closure, context);
+    context.validate();
+    return context;
+  }
+
+  public static ScmManagerApi createApi(ScmManagerApiFactory apiFactory, ScmManagerContext context) {
+    return apiFactory.create(Jenkins.get(), context.getServerUrl(), context.getCredentialsId());
+  }
+}

--- a/src/main/java/com/cloudogu/scmmanager/scm/jobdsl/NavigatorExtension.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/jobdsl/NavigatorExtension.java
@@ -1,0 +1,38 @@
+package com.cloudogu.scmmanager.scm.jobdsl;
+
+import com.cloudogu.scmmanager.scm.ScmManagerNavigator;
+import com.google.common.annotations.VisibleForTesting;
+import hudson.Extension;
+import javaposse.jobdsl.dsl.DslContext;
+import javaposse.jobdsl.dsl.RequiresPlugin;
+import javaposse.jobdsl.dsl.helpers.workflow.ScmNavigatorsContext;
+import javaposse.jobdsl.plugin.ContextExtensionPoint;
+import javaposse.jobdsl.plugin.DslExtensionMethod;
+
+import static com.cloudogu.scmmanager.scm.jobdsl.JobDSL.resolve;
+
+@Extension(optional = true)
+public class NavigatorExtension extends ContextExtensionPoint {
+
+  private final Executor executor;
+
+  public NavigatorExtension() {
+    this.executor = ContextExtensionPoint::executeInContext;
+  }
+
+  @VisibleForTesting
+  NavigatorExtension(Executor executor) {
+    this.executor = executor;
+  }
+
+  @RequiresPlugin(id = "scm-manager")
+  @DslExtensionMethod(context = ScmNavigatorsContext.class)
+  public ScmManagerNavigator scmManagerNamespace(@DslContext(ScmManagerNavigatorContext.class) Runnable closure) {
+    ScmManagerNavigatorContext context = resolve(executor, closure, new ScmManagerNavigatorContext(executor));
+    ScmManagerNavigator navigator = new ScmManagerNavigator(
+      context.getNamespace(), context.getServerUrl(), context.getNamespace(), context.getCredentialsId()
+    );
+    navigator.setTraits(context.getTraits());
+    return navigator;
+  }
+}

--- a/src/main/java/com/cloudogu/scmmanager/scm/jobdsl/ScmManagerContext.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/jobdsl/ScmManagerContext.java
@@ -1,0 +1,31 @@
+package com.cloudogu.scmmanager.scm.jobdsl;
+
+import com.google.common.base.Strings;
+import javaposse.jobdsl.dsl.Context;
+import javaposse.jobdsl.dsl.Preconditions;
+
+public class ScmManagerContext implements Context {
+
+  private String serverUrl;
+  private String credentialsId;
+
+  public String getServerUrl() {
+    return serverUrl;
+  }
+
+  public void serverUrl(String serverUrl) {
+    this.serverUrl = serverUrl;
+  }
+
+  public String getCredentialsId() {
+    return credentialsId;
+  }
+
+  public void credentialsId(String credentialsId) {
+    this.credentialsId = credentialsId;
+  }
+
+  public void validate() {
+    Preconditions.checkNotNullOrEmpty(serverUrl, "serverUrl is required");
+  }
+}

--- a/src/main/java/com/cloudogu/scmmanager/scm/jobdsl/ScmManagerNavigatorContext.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/jobdsl/ScmManagerNavigatorContext.java
@@ -1,0 +1,97 @@
+package com.cloudogu.scmmanager.scm.jobdsl;
+
+import com.cloudogu.scmmanager.scm.BranchDiscoveryTrait;
+import com.cloudogu.scmmanager.scm.PullRequestDiscoveryTrait;
+import com.cloudogu.scmmanager.scm.ScmManagerSvnNavigatorTrait;
+import com.cloudogu.scmmanager.scm.Subversion;
+import com.cloudogu.scmmanager.scm.TagDiscoveryTrait;
+import javaposse.jobdsl.dsl.Context;
+import javaposse.jobdsl.dsl.DslContext;
+import javaposse.jobdsl.dsl.Preconditions;
+import jenkins.scm.api.trait.SCMTrait;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ScmManagerNavigatorContext extends ScmManagerContext {
+
+  private String namespace;
+
+  private boolean discoverBranches = true;
+  private boolean discoverPullRequest = true;
+  private boolean discoverTags = false;
+  private boolean discoverSvn = Subversion.isSupported();
+
+  private String svnIncludes = Subversion.DEFAULT_INCLUDES;
+  private String svnExcludes = Subversion.DEFAULT_EXCLUDES;
+
+  private final Executor executor;
+
+  ScmManagerNavigatorContext(Executor executor) {
+    this.executor = executor;
+  }
+
+  public void namespace(String namespace) {
+    this.namespace = namespace;
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public void discoverBranches(boolean discoverBranches) {
+    this.discoverBranches = discoverBranches;
+  }
+
+  public void discoverPullRequest(boolean discoverPullRequest) {
+    this.discoverPullRequest = discoverPullRequest;
+  }
+
+  public void discoverTags(boolean discoverTags) {
+    this.discoverTags = discoverTags;
+  }
+
+  public void discoverSvn(boolean discoverSvn) {
+    this.discoverSvn = discoverSvn;
+  }
+
+  public void discoverSvn(@DslContext(SubversionContext.class) Runnable closure) {
+    this.discoverSvn = true;
+    executor.executeInContext(closure, new SubversionContext());
+  }
+
+  public List<SCMTrait<? extends SCMTrait<?>>> getTraits() {
+    List<SCMTrait<? extends SCMTrait<?>>> traits = new ArrayList<>();
+    if (discoverBranches) {
+      traits.add(new BranchDiscoveryTrait());
+    }
+    if (discoverPullRequest) {
+      traits.add(new PullRequestDiscoveryTrait());
+    }
+    if (discoverTags) {
+      traits.add(new TagDiscoveryTrait());
+    }
+    if (discoverSvn) {
+      traits.add(new ScmManagerSvnNavigatorTrait(svnIncludes, svnExcludes));
+    }
+    return traits;
+  }
+
+  @Override
+  public void validate() {
+    super.validate();
+    Preconditions.checkNotNullOrEmpty(namespace, "namespace is required");
+  }
+
+  public class SubversionContext implements Context {
+
+    public void includes(String includes) {
+      svnIncludes = includes;
+    }
+
+    public void excludes(String excludes) {
+      svnExcludes = excludes;
+    }
+
+  }
+}

--- a/src/test/java/com/cloudogu/scmmanager/scm/jobdsl/Asserts.java
+++ b/src/test/java/com/cloudogu/scmmanager/scm/jobdsl/Asserts.java
@@ -1,0 +1,24 @@
+package com.cloudogu.scmmanager.scm.jobdsl;
+
+import jenkins.scm.api.trait.SCMTrait;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Asserts {
+
+  private Asserts() {
+  }
+
+  public static void assertContainsOnlyInstancesOf(Collection<?> instances, Class<?>... expected) {
+    Set<Class<?>> classes = instances.stream()
+      .map(Object::getClass)
+      .collect(Collectors.toSet());
+    assertThat(classes).containsOnly(expected);
+  }
+
+}

--- a/src/test/java/com/cloudogu/scmmanager/scm/jobdsl/NavigatorExtensionTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/scm/jobdsl/NavigatorExtensionTest.java
@@ -1,0 +1,94 @@
+package com.cloudogu.scmmanager.scm.jobdsl;
+
+import com.cloudogu.scmmanager.scm.BranchDiscoveryTrait;
+import com.cloudogu.scmmanager.scm.PullRequestDiscoveryTrait;
+import com.cloudogu.scmmanager.scm.ScmManagerNavigator;
+import com.cloudogu.scmmanager.scm.ScmManagerSvnNavigatorTrait;
+import com.cloudogu.scmmanager.scm.TagDiscoveryTrait;
+import javaposse.jobdsl.dsl.DslScriptException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static com.cloudogu.scmmanager.scm.jobdsl.Asserts.assertContainsOnlyInstancesOf;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NavigatorExtensionTest {
+
+  @Rule
+  public JenkinsRule jenkinsRule = new JenkinsRule();
+
+  @Test
+  public void shouldCreateNavigator() {
+    NavigatorExtension extension = new NavigatorExtension((runnable, ctx) -> {
+      ScmManagerNavigatorContext context = (ScmManagerNavigatorContext) ctx;
+      context.serverUrl("https://scm.hitchhiker.com/scm");
+      context.credentialsId("secret");
+      context.namespace("spaceships");
+      context.discoverSvn(false);
+    });
+
+    ScmManagerNavigator scmNavigator = extension.scmManagerNamespace(null);
+    assertThat(scmNavigator.getServerUrl()).isEqualTo("https://scm.hitchhiker.com/scm");
+    assertThat(scmNavigator.getCredentialsId()).isEqualTo("secret");
+    assertThat(scmNavigator.getNamespace()).isEqualTo("spaceships");
+    assertContainsOnlyInstancesOf(scmNavigator.getTraits(),
+      BranchDiscoveryTrait.class, PullRequestDiscoveryTrait.class
+    );
+  }
+
+  @Test
+  public void shouldDisableDefaultTraits() {
+    NavigatorExtension extension = new NavigatorExtension((runnable, ctx) -> {
+      ScmManagerNavigatorContext context = (ScmManagerNavigatorContext) ctx;
+      context.serverUrl("https://scm.hitchhiker.com/scm");
+      context.credentialsId("secret");
+      context.namespace("spaceships");
+      context.discoverBranches(false);
+      context.discoverPullRequest(false);
+      context.discoverTags(true);
+      context.discoverSvn(true);
+    });
+
+    ScmManagerNavigator scmNavigator = extension.scmManagerNamespace(null);
+    assertContainsOnlyInstancesOf(scmNavigator.getTraits(),
+      TagDiscoveryTrait.class, ScmManagerSvnNavigatorTrait.class
+    );
+  }
+
+  @Test
+  public void shouldConfigureIncludesAndExcludesOfSubversionTrait() {
+    NavigatorExtension extension = new NavigatorExtension((runnable, ctx) -> {
+      if (ctx instanceof ScmManagerNavigatorContext) {
+        ScmManagerNavigatorContext context = (ScmManagerNavigatorContext) ctx;
+        context.serverUrl("https://scm.hitchhiker.com/scm");
+        context.credentialsId("secret");
+        context.namespace("spaceships");
+        context.discoverBranches(false);
+        context.discoverPullRequest(false);
+        context.discoverSvn(() -> {});
+      } else if (ctx instanceof ScmManagerNavigatorContext.SubversionContext) {
+        ScmManagerNavigatorContext.SubversionContext context = (ScmManagerNavigatorContext.SubversionContext) ctx;
+        context.includes("tags");
+        context.excludes("tags/0.*");
+      }
+    });
+
+    ScmManagerNavigator scmNavigator = extension.scmManagerNamespace(null);
+    ScmManagerSvnNavigatorTrait trait = (ScmManagerSvnNavigatorTrait) scmNavigator.getTraits().get(0);
+    assertThat(trait.getIncludes()).isEqualTo("tags");
+    assertThat(trait.getExcludes()).isEqualTo("tags/0.*");
+  }
+
+  @Test(expected = DslScriptException.class)
+  public void shouldFailWithoutNamespace() {
+    NavigatorExtension extension = new NavigatorExtension((runnable, ctx) -> {
+      ScmManagerNavigatorContext context = (ScmManagerNavigatorContext) ctx;
+      context.serverUrl("https://scm.hitchhiker.com/scm");
+      context.credentialsId("secret");
+    });
+
+    extension.scmManagerNamespace(null);
+  }
+
+}


### PR DESCRIPTION
Add custom JobDSL syntax for the creation of an ScmManagerNavigator e.g.:

```groovy
organizationFolder("spaceships") {
  organizations {
    scmManagerNamespace {
      serverUrl('https://scm.hitchhiker.com')
      credentialsId('my-secret-id')
      namespace("spaceships")
      discoverBranches(true)
      discoverPullRequest(true)
      discoverTags(false)
      discoverSvn {
        includes("trunk,branches/*,tags/*,sandbox/*")
        excludes("")
      }
    }
  }
}
// scan namespace directly after creation
queue("spaceships")
```