### PR TITLE
Fire branch events for pull requests, too

### DIFF
--- a/src/main/java/com/cloudogu/scmmanager/scm/ScmManagerBranchEventFromPullRequest.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/ScmManagerBranchEventFromPullRequest.java
@@ -1,0 +1,40 @@
+package com.cloudogu.scmmanager.scm;
+
+import com.cloudogu.scmmanager.scm.api.CloneInformation;
+import com.cloudogu.scmmanager.scm.api.ScmManagerHead;
+import jenkins.scm.api.SCMHead;
+import net.sf.json.JSONObject;
+
+import java.util.Collection;
+
+import static java.util.stream.Collectors.toList;
+
+public class ScmManagerBranchEventFromPullRequest extends ScmManagerHeadEvent {
+
+  private Collection<String> names;
+
+  ScmManagerBranchEventFromPullRequest(Type type, JSONObject form, Collection<JSONObject> pullRequests) {
+    super(correspondingTypeForBranch(type), form);
+    this.names = pullRequests.stream().map(branch -> branch.getString("source")).collect(toList());
+  }
+
+  private static Type correspondingTypeForBranch(Type type) {
+    switch (type) {
+      case CREATED:
+      case UPDATED:
+        // When a pull request is created or changed, the corresponding branch may be to be removed
+        return Type.REMOVED;
+      case REMOVED:
+        // When a pul request is removed, the corresponding branch may be to be build again
+        return Type.CREATED;
+      default:
+        // The most secure way:
+        return Type.CREATED;
+    }
+  }
+
+  @Override
+  Collection<SCMHead> heads(CloneInformation cloneInformation) {
+    return names.stream().map(name -> new ScmManagerHead(cloneInformation, name)).collect(toList());
+  }
+}

--- a/src/main/java/com/cloudogu/scmmanager/scm/ScmManagerWebHook.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/ScmManagerWebHook.java
@@ -64,7 +64,9 @@ public class ScmManagerWebHook implements UnprotectedRootAction {
       fireIfPresent(form, "deletedTags", tags -> new ScmManagerTagEvent(REMOVED, form, tags));
       fireIfPresent(form, "createOrModifiedTags", tags -> new ScmManagerTagEvent(UPDATED, form, tags));
       fireIfPresent(form, "deletedPullRequests", pullRequests -> new ScmManagerPullRequestEvent(REMOVED, form, pullRequests));
+      fireIfPresent(form, "deletedPullRequests", pullRequests -> new ScmManagerBranchEventFromPullRequest(REMOVED, form, pullRequests));
       fireIfPresent(form, "createOrModifiedPullRequests", pullRequests -> new ScmManagerPullRequestEvent(UPDATED, form, pullRequests));
+      fireIfPresent(form, "createOrModifiedPullRequests", pullRequests -> new ScmManagerBranchEventFromPullRequest(UPDATED, form, pullRequests));
 
       if (form.containsKey("createdOrModifiedBranches")) {
         // the creation or the change of a branch can also lead to a new source for navigators


### PR DESCRIPTION
This is necessary, because a created or deleted pull request
may lead to the need to build or not build branches, when
the "Exclude Branches with open PRs" option is selected.