### PR TITLE
Fix class not found exception without Subversion plugin

### DIFF
--- a/src/main/java/com/cloudogu/scmmanager/scm/ScmManagerSvnRepositoryBrowser.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/ScmManagerSvnRepositoryBrowser.java
@@ -62,7 +62,7 @@ public class ScmManagerSvnRepositoryBrowser extends SubversionRepositoryBrowser 
     return new URL(builder.changeset(getRevision(changeSet)));
   }
 
-  @Extension
+  @Extension(optional = true)
   public static class DescriptorImpl extends Descriptor<RepositoryBrowser<?>> {
     @Override
     public String getDisplayName() {

--- a/src/main/java/com/cloudogu/scmmanager/scm/ScmManagerSvnSourceBuilder.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/ScmManagerSvnSourceBuilder.java
@@ -2,9 +2,10 @@ package com.cloudogu.scmmanager.scm;
 
 import com.google.common.base.Strings;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.trait.SCMSourceBuilder;
 
-public class ScmManagerSvnSourceBuilder extends SCMSourceBuilder<ScmManagerSvnSourceBuilder, ScmManagerSvnSource> {
+public class ScmManagerSvnSourceBuilder extends SCMSourceBuilder<ScmManagerSvnSourceBuilder, SCMSource> {
 
   private final String serverUrl;
   private final String repository;
@@ -15,7 +16,7 @@ public class ScmManagerSvnSourceBuilder extends SCMSourceBuilder<ScmManagerSvnSo
   private String excludes;
 
   public ScmManagerSvnSourceBuilder(String projectName, String serverUrl, String repository, String credentialsId) {
-    super(ScmManagerSvnSource.class, projectName);
+    super(SCMSource.class, projectName);
     this.serverUrl = serverUrl;
     this.repository = repository;
     this.credentialsId = credentialsId;
@@ -38,7 +39,7 @@ public class ScmManagerSvnSourceBuilder extends SCMSourceBuilder<ScmManagerSvnSo
 
   @NonNull
   @Override
-  public ScmManagerSvnSource build() {
+  public SCMSource build() {
     ScmManagerSvnSource source = new ScmManagerSvnSource(id, serverUrl, repository, credentialsId);
     if (!Strings.isNullOrEmpty(includes)) {
       source.setIncludes(includes);


### PR DESCRIPTION
Fixes https://issues.jenkins.io/browse/JENKINS-64985

A `ClassNotFoundException` was thrown while creating namespace jobs, when the Subversion plugin is not installed. The stack trace looked something like this:

```
java.lang.ClassNotFoundException: jenkins.scm.impl.subversion.SubversionSCMSource
        at jenkins.util.AntClassLoader.findClassInComponents(AntClassLoader.java:1387)
        at jenkins.util.AntClassLoader.findClass(AntClassLoader.java:1342)
        at jenkins.util.AntClassLoader.loadClass(AntClassLoader.java:1089)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
Caused: java.lang.NoClassDefFoundError: jenkins/scm/impl/subversion/SubversionSCMSource
        at java.base/java.lang.ClassLoader.defineClass1(Native Method)
        at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
        at jenkins.util.AntClassLoader.defineClassFromData(AntClassLoader.java:1155)
        at hudson.ClassicPluginStrategy$AntClassLoader2.defineClassFromData(ClassicPluginStrategy.java:715)
        at jenkins.util.AntClassLoader.getClassFromStream(AntClassLoader.java:1326)
        at jenkins.util.AntClassLoader.findClassInComponents(AntClassLoader.java:1377)
        at jenkins.util.AntClassLoader.findClass(AntClassLoader.java:1342)
        at jenkins.util.AntClassLoader.loadClass(AntClassLoader.java:1089)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        at com.cloudogu.scmmanager.scm.ScmManagerNavigator.visitSources(ScmManagerNavigator.java:142)
        at jenkins.branch.OrganizationFolder.computeChildren(OrganizationFolder.java:542)
        at com.cloudbees.hudson.plugins.folder.computed.ComputedFolder.updateChildren(ComputedFolder.java:278)
        at com.cloudbees.hudson.plugins.folder.computed.FolderComputation.run(FolderComputation.java:165)
        at jenkins.branch.OrganizationFolder$OrganizationScan.run(OrganizationFolder.java:1033)
        at hudson.model.ResourceController.execute(ResourceController.java:97)
        at hudson.model.Executor.run(Executor.java:429)
```

This was due to a reference to a classes only available in the Subversion plugin in `ScmManagerSvnSource`, and that class in turn was a part of the public API of `ScmManagerSvnSourceBuilder` due to the generic. But this class is used in `ScmManagerNavigator.ScmManagerSvnSourceBuilder` and therefore has to be loaded when a job shall be created.

By using `SCMSource` in the generic instead of the special implementation of the Subversion plugin, we can remove this class from the public API, and therefore this class no longer needs to be loaded unless it is needed.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes

<!--
Put an `x` into the [ ] to show you have filled the information
-->
