### PR TITLE
Handle build library checkouts

### DIFF
--- a/src/main/java/com/cloudogu/scmmanager/CheckoutListener.java
+++ b/src/main/java/com/cloudogu/scmmanager/CheckoutListener.java
@@ -32,9 +32,9 @@ public class CheckoutListener extends SCMListener {
   }
 
   @Override
-  public void onCheckout(Run<?, ?> build, SCM scm, FilePath workspace, TaskListener listener, @CheckForNull File changelogFile, @CheckForNull SCMRevisionState pollingBaseline) {
-    List<JobInformation> jobInformation = informationService.resolve(build, scm);
-    build.addAction(new NotificationAction(jobInformation));
-    notificationService.notify(build, null);
+  public void onCheckout(Run<?, ?> run, SCM scm, FilePath workspace, TaskListener listener, @CheckForNull File changelogFile, @CheckForNull SCMRevisionState pollingBaseline) {
+    List<JobInformation> jobInformation = informationService.resolve(run, scm);
+    run.addAction(new NotificationAction(jobInformation));
+    notificationService.notify(run, null);
   }
 }

--- a/src/main/java/com/cloudogu/scmmanager/NotificationService.java
+++ b/src/main/java/com/cloudogu/scmmanager/NotificationService.java
@@ -10,8 +10,10 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 class NotificationService {
 
@@ -31,13 +33,17 @@ class NotificationService {
       return;
     }
 
-    NotificationAction action = run.getAction(NotificationAction.class);
-    if (action == null) {
+    Collection<NotificationAction> actions = run.getActions(NotificationAction.class);
+    if (actions == null || actions.isEmpty()) {
       LOG.info("no notification action is attached to build {}", run);
       return;
     }
 
-    List<JobInformation> informationList = action.getJobInformation();
+    List<JobInformation> informationList = actions
+      .stream()
+      .map(NotificationAction::getJobInformation)
+      .flatMap(List::stream)
+      .collect(Collectors.toList());
     if (informationList.isEmpty()) {
       LOG.info("no scm information could be extracted from build {}", run);
       return;

--- a/src/main/java/com/cloudogu/scmmanager/info/GitScmInformationResolver.java
+++ b/src/main/java/com/cloudogu/scmmanager/info/GitScmInformationResolver.java
@@ -8,12 +8,14 @@ import hudson.plugins.git.Revision;
 import hudson.plugins.git.UserRemoteConfig;
 import hudson.plugins.git.util.BuildData;
 import hudson.scm.SCM;
+import jenkins.plugins.git.GitSCMSource;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Extension(optional = true)
 public class GitScmInformationResolver implements ScmInformationResolver {
@@ -28,9 +30,19 @@ public class GitScmInformationResolver implements ScmInformationResolver {
 
     GitSCM git = (GitSCM) scm;
 
+    Collection<String> remoteBases = SourceUtil
+      .getSources(run, GitSCMSource.class, GitSCMSource::getRemote);
+
+    if (remoteBases.isEmpty()) {
+      return Collections.emptyList();
+    }
+
     Optional<String> revision = getRevision(run, git);
     if (revision.isPresent()) {
-      return createInformation(git, revision.get());
+      return createInformation(git, revision.get())
+        .stream()
+        .filter(jobInformation -> remoteBases.contains(jobInformation.getUrl()))
+        .collect(Collectors.toList());
     } else {
       return Collections.emptyList();
     }
@@ -41,7 +53,7 @@ public class GitScmInformationResolver implements ScmInformationResolver {
     for (UserRemoteConfig urc : git.getUserRemoteConfigs()) {
       information.add(createInformation(urc, revision));
     }
-    return Collections.unmodifiableList(information);
+    return information;
   }
 
   private JobInformation createInformation(UserRemoteConfig urc, String revision) {

--- a/src/main/java/com/cloudogu/scmmanager/info/HgScmInformationResolver.java
+++ b/src/main/java/com/cloudogu/scmmanager/info/HgScmInformationResolver.java
@@ -3,6 +3,7 @@ package com.cloudogu.scmmanager.info;
 import com.google.common.base.Strings;
 import hudson.model.Run;
 import hudson.plugins.mercurial.MercurialSCM;
+import hudson.plugins.mercurial.MercurialSCMSource;
 import hudson.scm.SCM;
 
 import java.util.Collection;
@@ -22,6 +23,13 @@ public class HgScmInformationResolver implements ScmInformationResolver {
 
     MercurialSCM hg = (MercurialSCM) scm;
 
+    Collection<String> remoteBases = SourceUtil
+      .getSources(run, MercurialSCMSource.class, MercurialSCMSource::getSource);
+
+    if (remoteBases.isEmpty()) {
+      return Collections.emptyList();
+    }
+
     String source = hg.getSource();
     String revision = getRevision(hg, run);
 
@@ -30,7 +38,12 @@ public class HgScmInformationResolver implements ScmInformationResolver {
     }
 
     JobInformation config = new JobInformation(TYPE, source, revision, hg.getCredentialsId(), false);
-    return Collections.singleton(config);
+
+    if (remoteBases.contains(config.getUrl())) {
+      return Collections.singleton(config);
+    }
+
+    return Collections.emptyList();
   }
 
   private String getRevision(MercurialSCM scm, Run<?, ?> run) {

--- a/src/main/java/com/cloudogu/scmmanager/info/SourceUtil.java
+++ b/src/main/java/com/cloudogu/scmmanager/info/SourceUtil.java
@@ -1,0 +1,58 @@
+package com.cloudogu.scmmanager.info;
+
+import com.cloudogu.scmmanager.scm.ScmManagerSource;
+import hudson.model.Item;
+import hudson.model.Run;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceOwner;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public final class SourceUtil {
+
+  private SourceUtil() {
+  }
+
+  static <T extends SCMSource> List<String> getSources(Run<?, ?> run, Class<T> sourceType, Function<T, String> urlExtractor) {
+    return extractSourceOwner(run)
+      .map(sourceOwner ->
+        sourceOwner
+          .getSCMSources()
+          .stream()
+          .filter(scmSource -> canExtract(scmSource, sourceType))
+          .map(scmSource -> extract(scmSource, sourceType, urlExtractor))
+          .collect(Collectors.toList())
+      ).orElse(Collections.emptyList());
+  }
+
+  private static Optional<SCMSourceOwner> extractSourceOwner(Run<?, ?> run) {
+    Object current = run.getParent();
+    while (!(current instanceof SCMSourceOwner)) {
+      if (current == null) {
+        return Optional.empty();
+      } else if (current instanceof Item) {
+        current = ((Item) current).getParent();
+      } else {
+        return Optional.empty();
+      }
+    }
+    return Optional.of((SCMSourceOwner) current);
+
+  }
+
+  private static boolean canExtract(SCMSource scmSource, Class<?> sourceType) {
+    return sourceType.isAssignableFrom(scmSource.getClass()) || scmSource instanceof ScmManagerSource;
+  }
+
+  private static <T> String extract(SCMSource scmSource, Class<T> sourceType, Function<T, String> urlExtractor) {
+    if (scmSource instanceof ScmManagerSource) {
+      return ((ScmManagerSource) scmSource).getRemoteUrl();
+    } else {
+      return urlExtractor.apply(sourceType.cast(scmSource));
+    }
+  }
+}

--- a/src/main/java/com/cloudogu/scmmanager/info/SourceUtil.java
+++ b/src/main/java/com/cloudogu/scmmanager/info/SourceUtil.java
@@ -29,7 +29,7 @@ public final class SourceUtil {
       ).orElse(Collections.emptyList());
   }
 
-  private static Optional<SCMSourceOwner> extractSourceOwner(Run<?, ?> run) {
+  static Optional<SCMSourceOwner> extractSourceOwner(Run<?, ?> run) {
     return extractSourceOwner(run.getParent());
   }
 

--- a/src/main/java/com/cloudogu/scmmanager/info/SourceUtil.java
+++ b/src/main/java/com/cloudogu/scmmanager/info/SourceUtil.java
@@ -30,18 +30,17 @@ public final class SourceUtil {
   }
 
   private static Optional<SCMSourceOwner> extractSourceOwner(Run<?, ?> run) {
-    Object current = run.getParent();
-    while (!(current instanceof SCMSourceOwner)) {
-      if (current == null) {
-        return Optional.empty();
-      } else if (current instanceof Item) {
-        current = ((Item) current).getParent();
-      } else {
-        return Optional.empty();
-      }
-    }
-    return Optional.of((SCMSourceOwner) current);
+    return extractSourceOwner(run.getParent());
+  }
 
+  private static Optional<SCMSourceOwner> extractSourceOwner(Object parent) {
+    if (parent instanceof SCMSourceOwner) {
+      return Optional.of((SCMSourceOwner) parent);
+    } else if (parent instanceof Item) {
+      return extractSourceOwner(((Item) parent).getParent());
+    } else {
+      return Optional.empty();
+    }
   }
 
   private static boolean canExtract(SCMSource scmSource, Class<?> sourceType) {

--- a/src/main/java/com/cloudogu/scmmanager/info/SvnScmInformationResolver.java
+++ b/src/main/java/com/cloudogu/scmmanager/info/SvnScmInformationResolver.java
@@ -26,14 +26,6 @@ public class SvnScmInformationResolver implements ScmInformationResolver {
 
     SubversionSCM svn = (SubversionSCM) scm;
 
-
-    Collection<String> remoteBases = SourceUtil
-      .getSources(run, SubversionSCMSource.class, SubversionSCMSource::getRemoteBase);
-
-    if (remoteBases.isEmpty()) {
-      return Collections.emptyList();
-    }
-
     Map<String, String> env = new HashMap<>();
     svn.buildEnvironment(run, env);
 
@@ -42,6 +34,18 @@ public class SvnScmInformationResolver implements ScmInformationResolver {
     if (locations != null) {
       appendInformation(configurations, locations, env);
     }
+
+    if (!SourceUtil.extractSourceOwner(run).isPresent()) {
+      return configurations;
+    }
+
+    Collection<String> remoteBases = SourceUtil
+      .getSources(run, SubversionSCMSource.class, SubversionSCMSource::getRemoteBase);
+
+    if (remoteBases.isEmpty()) {
+      return Collections.emptyList();
+    }
+
     return configurations
       .stream()
       .filter(jobInformation -> remoteBases.stream().anyMatch(remoteBase -> jobInformation.getUrl().startsWith(remoteBase)))

--- a/src/main/java/com/cloudogu/scmmanager/scm/ScmManagerSource.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/ScmManagerSource.java
@@ -250,6 +250,10 @@ public class ScmManagerSource extends SCMSource {
     return linkBuilder;
   }
 
+  public String getRemoteUrl() {
+    return new LinkBuilder(serverUrl, namespace, name).repo();
+  }
+
   @Extension
   @Symbol("scmManager")
   public static class DescriptorImpl extends ScmManagerSourceDescriptor {

--- a/src/test/java/com/cloudogu/scmmanager/NotificationServiceTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/NotificationServiceTest.java
@@ -88,7 +88,7 @@ public class NotificationServiceTest {
   private CapturingNotifier getNotifier() {
     for (NotifierProvider provider : NotifierProvider.all()) {
       if (provider instanceof SampleNotifierProvider) {
-        return ((SampleNotifierProvider)provider).notifier;
+        return ((SampleNotifierProvider) provider).notifier;
       }
     }
     throw new IllegalStateException("could not find CapturingNotifier");

--- a/src/test/java/com/cloudogu/scmmanager/NotificationServiceTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/NotificationServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
@@ -58,7 +59,7 @@ public class NotificationServiceTest {
 
   private void mockJobInformation(JobInformation... information) {
     NotificationAction action = new NotificationAction(Arrays.asList(information));
-    when(run.getAction(NotificationAction.class)).thenReturn(action);
+    when(run.getActions(NotificationAction.class)).thenReturn(Collections.singletonList(action));
   }
 
   @Test

--- a/src/test/java/com/cloudogu/scmmanager/info/GitScmInformationResolverTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/info/GitScmInformationResolverTest.java
@@ -92,6 +92,22 @@ public class GitScmInformationResolverTest {
     Assertions.info(it.next(), "git", "abc42", "https://scm.scm-manager.org/repo/ns/two", "scm-two");
   }
 
+  @Test
+  public void testResolveWithoutSourceOwner() {
+    applyRevision("abc42");
+    applyUrcs(
+      urc("https://scm.scm-manager.org/repo/ns/one", "scm-one"),
+      urc("https://scm.scm-manager.org/repo/ns/two", "scm-two")
+    );
+
+    Collection<JobInformation> information = resolver.resolve(run, git);
+    assertEquals(2, information.size());
+
+    Iterator<JobInformation> it = information.iterator();
+    Assertions.info(it.next(), "git", "abc42", "https://scm.scm-manager.org/repo/ns/one", "scm-one");
+    Assertions.info(it.next(), "git", "abc42", "https://scm.scm-manager.org/repo/ns/two", "scm-two");
+  }
+
   private UserRemoteConfig urc(String url, String credentialsId) {
     return new UserRemoteConfig(url, null, null, credentialsId);
   }

--- a/src/test/java/com/cloudogu/scmmanager/info/GitScmInformationResolverTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/info/GitScmInformationResolverTest.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 
+import static com.cloudogu.scmmanager.info.SourceUtilTestHelper.mockSource;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -27,7 +28,7 @@ public class GitScmInformationResolverTest {
   private GitSCM git;
 
   @Mock
-  private Run<?, ?> run;
+  private Run<TestJob, TestRun> run;
 
   private final GitScmInformationResolver resolver = new GitScmInformationResolver();
 
@@ -48,6 +49,7 @@ public class GitScmInformationResolverTest {
   public void testResolveWithoutRevision() {
     BuildData buildData = mock(BuildData.class);
     when(git.getBuildData(run)).thenReturn(buildData);
+    mockSource(run, "https://scm.scm-manager.org/repo/ns/one");
 
     Collection<JobInformation> information = resolver.resolve(run, git);
     assertTrue(information.isEmpty());
@@ -55,6 +57,7 @@ public class GitScmInformationResolverTest {
 
   @Test
   public void testResolveWithoutSha1() {
+    mockSource(run, "https://scm.scm-manager.org/repo/ns/one");
     BuildData buildData = mock(BuildData.class);
     Revision revision = mock(Revision.class);
     when(buildData.getLastBuiltRevision()).thenReturn(revision);
@@ -74,6 +77,7 @@ public class GitScmInformationResolverTest {
 
   @Test
   public void testResolve() {
+    mockSource(run, "https://scm.scm-manager.org/repo/ns/one", "https://scm.scm-manager.org/repo/ns/two");
     applyRevision("abc42");
     applyUrcs(
       urc("https://scm.scm-manager.org/repo/ns/one", "scm-one"),

--- a/src/test/java/com/cloudogu/scmmanager/info/HgScmInformationResolverTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/info/HgScmInformationResolverTest.java
@@ -1,15 +1,29 @@
 package com.cloudogu.scmmanager.info;
 
+import com.cloudogu.scmmanager.scm.ScmManagerSource;
+import hudson.model.Item;
+import hudson.model.ItemGroup;
+import hudson.model.Job;
 import hudson.model.Run;
+import hudson.model.TopLevelItem;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.mercurial.MercurialSCM;
+import jenkins.model.Jenkins;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceOwner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.jvnet.hudson.reactor.ReactorException;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import javax.annotation.Nonnull;
+import javax.servlet.ServletContext;
+import java.io.File;
+import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -23,7 +37,14 @@ public class HgScmInformationResolverTest {
   private MercurialSCM hg;
 
   @Mock
-  private Run<?, ?> run;
+  private Run<TestJob, TestRun> run;
+
+  @Mock
+  private TestJob job;
+  @Mock
+  private TestSCMSourceOwner sourceOwner;
+  @Mock
+  private ScmManagerSource scmSource;
 
   private final HgScmInformationResolver resolver = new HgScmInformationResolver();
 
@@ -45,7 +66,7 @@ public class HgScmInformationResolverTest {
 
   @Test
   public void testResolveWithoutRevision() {
-    when(hg.getSource()).thenReturn("https://scm.scm-manager.org/repo/ns/one");
+    mockSource();
 
     Collection<JobInformation> information = resolver.resolve(run, hg);
     assertTrue(information.isEmpty());
@@ -53,7 +74,7 @@ public class HgScmInformationResolverTest {
 
   @Test
   public void testResolve() {
-    when(hg.getSource()).thenReturn("https://scm.scm-manager.org/repo/ns/one");
+    mockSource();
     applyRevision("42abc");
     when(hg.getCredentialsId()).thenReturn("scm-one");
 
@@ -68,6 +89,15 @@ public class HgScmInformationResolverTest {
     );
   }
 
+  private void mockSource() {
+    doReturn(job).when(run).getParent();
+    doReturn(sourceOwner).when(job).getParent();
+    doReturn(Collections.singletonList(scmSource)).when(sourceOwner).getSCMSources();
+    doReturn("https://scm.scm-manager.org/repo/ns/one").when(scmSource).getRemoteUrl();
+
+    doReturn("https://scm.scm-manager.org/repo/ns/one").when(hg).getSource();
+  }
+
   @SuppressWarnings("unchecked")
   private void applyRevision(String revision) {
     doAnswer((ic) -> {
@@ -77,4 +107,21 @@ public class HgScmInformationResolverTest {
     }).when(hg).buildEnvironment(any(Run.class), any(Map.class));
   }
 
+  private static abstract class TestRun extends Run<TestJob, TestRun> {
+    protected TestRun(@Nonnull TestJob job) throws IOException {
+      super(job);
+    }
+  }
+
+  private static abstract class TestJob extends Job<TestJob, TestRun> {
+    protected TestJob(ItemGroup parent, String name) {
+      super(parent, name);
+    }
+  }
+
+  private static abstract class TestSCMSourceOwner extends Jenkins implements SCMSourceOwner {
+    protected TestSCMSourceOwner(File root, ServletContext context) throws IOException, InterruptedException, ReactorException {
+      super(root, context);
+    }
+  }
 }

--- a/src/test/java/com/cloudogu/scmmanager/info/HgScmInformationResolverTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/info/HgScmInformationResolverTest.java
@@ -73,6 +73,23 @@ public class HgScmInformationResolverTest {
     );
   }
 
+  @Test
+  public void testResolveWithoutSourceOwner() {
+    doReturn("https://scm.scm-manager.org/repo/ns/one").when(hg).getSource();
+    applyRevision("42abc");
+    when(hg.getCredentialsId()).thenReturn("scm-one");
+
+    Collection<JobInformation> information = resolver.resolve(run, hg);
+    assertEquals(1, information.size());
+    Assertions.info(
+      information.iterator().next(),
+      "hg",
+      "42abc",
+      "https://scm.scm-manager.org/repo/ns/one",
+      "scm-one"
+    );
+  }
+
   @SuppressWarnings("unchecked")
   private void applyRevision(String revision) {
     doAnswer((ic) -> {

--- a/src/test/java/com/cloudogu/scmmanager/info/SourceUtilTestHelper.java
+++ b/src/test/java/com/cloudogu/scmmanager/info/SourceUtilTestHelper.java
@@ -1,0 +1,31 @@
+package com.cloudogu.scmmanager.info;
+
+import com.cloudogu.scmmanager.scm.ScmManagerSource;
+import hudson.model.Run;
+import junit.framework.TestCase;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+class SourceUtilTestHelper extends TestCase {
+  static void mockSource(Run<TestJob, TestRun> run, String... urls) {
+    TestJob job = mock(TestJob.class);
+    TestSCMSourceOwner sourceOwner = mock(TestSCMSourceOwner.class);
+
+    doReturn(job).when(run).getParent();
+    doReturn(sourceOwner).when(job).getParent();
+
+    List<ScmManagerSource> sources = Arrays.stream(urls).map(SourceUtilTestHelper::createSource).collect(Collectors.toList());
+    doReturn(sources).when(sourceOwner).getSCMSources();
+  }
+
+  private static ScmManagerSource createSource(String url) {
+    ScmManagerSource scmSource = mock(ScmManagerSource.class);
+    doReturn(url).when(scmSource).getRemoteUrl();
+    return scmSource;
+  }
+}

--- a/src/test/java/com/cloudogu/scmmanager/info/SourceUtilTestHelper.java
+++ b/src/test/java/com/cloudogu/scmmanager/info/SourceUtilTestHelper.java
@@ -2,7 +2,6 @@ package com.cloudogu.scmmanager.info;
 
 import com.cloudogu.scmmanager.scm.ScmManagerSource;
 import hudson.model.Run;
-import junit.framework.TestCase;
 
 import java.util.Arrays;
 import java.util.List;
@@ -11,7 +10,11 @@ import java.util.stream.Collectors;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
-class SourceUtilTestHelper extends TestCase {
+final class SourceUtilTestHelper {
+
+  private SourceUtilTestHelper() {
+  }
+
   static void mockSource(Run<TestJob, TestRun> run, String... urls) {
     TestJob job = mock(TestJob.class);
     TestSCMSourceOwner sourceOwner = mock(TestSCMSourceOwner.class);

--- a/src/test/java/com/cloudogu/scmmanager/info/SvnScmInformationResolverTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/info/SvnScmInformationResolverTest.java
@@ -82,7 +82,7 @@ public class SvnScmInformationResolverTest {
   }
 
   @Test
-  public void testResolveMutlipleWithTooFewRevision() {
+  public void testResolveMultipleWithTooFewRevision() {
     mockSource(
       run,
       "https://scm.scm-manager.org/repo/ns/one",
@@ -92,6 +92,18 @@ public class SvnScmInformationResolverTest {
       location("https://scm.scm-manager.org/repo/ns/one", "scm-one"),
       location("https://scm.scm-manager.org/repo/ns/two", "scm-two"),
       location("https://scm.scm-manager.org/repo/ns/three", "scm-three")
+    );
+    applyRevisions(42, 21);
+
+    Collection<JobInformation> information = resolver.resolve(run, svn);
+    assertEquals(2, information.size());
+  }
+
+  @Test
+  public void testResolveMultipleWithoutSourceOwner() {
+    applyLocations(
+      location("https://scm.scm-manager.org/repo/ns/one", "scm-one"),
+      location("https://scm.scm-manager.org/repo/ns/two", "scm-two")
     );
     applyRevisions(42, 21);
 

--- a/src/test/java/com/cloudogu/scmmanager/info/SvnScmInformationResolverTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/info/SvnScmInformationResolverTest.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 
+import static com.cloudogu.scmmanager.info.SourceUtilTestHelper.mockSource;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -26,7 +27,7 @@ public class SvnScmInformationResolverTest {
   private SubversionSCM svn;
 
   @Mock
-  private Run<?, ?> run;
+  private Run<TestJob, TestRun> run;
 
   private final SvnScmInformationResolver resolver = new SvnScmInformationResolver();
 
@@ -46,6 +47,7 @@ public class SvnScmInformationResolverTest {
 
   @Test
   public void testResolveWithEmptyLocations() {
+    mockSource(run, "https://scm.scm-manager.org/repo/ns/one");
     when(svn.getLocations()).thenReturn(new SubversionSCM.ModuleLocation[0]);
 
     Collection<JobInformation> information = resolver.resolve(run, svn);
@@ -54,6 +56,7 @@ public class SvnScmInformationResolverTest {
 
   @Test
   public void testResolveWithOneLocation() {
+    mockSource(run, "https://scm.scm-manager.org/repo/ns/one");
     applyLocations(location("https://scm.scm-manager.org/repo/ns/one", "scm-one"));
     applyRevisions(42);
 
@@ -71,6 +74,7 @@ public class SvnScmInformationResolverTest {
 
   @Test
   public void testResolveOneWithoutRevision() {
+    mockSource(run, "https://scm.scm-manager.org/repo/ns/one");
     applyLocations(location("https://scm.scm-manager.org/repo/ns/one", "scm-one"));
 
     Collection<JobInformation> information = resolver.resolve(run, svn);
@@ -79,6 +83,11 @@ public class SvnScmInformationResolverTest {
 
   @Test
   public void testResolveMutlipleWithTooFewRevision() {
+    mockSource(
+      run,
+      "https://scm.scm-manager.org/repo/ns/one",
+      "https://scm.scm-manager.org/repo/ns/two",
+      "https://scm.scm-manager.org/repo/ns/three");
     applyLocations(
       location("https://scm.scm-manager.org/repo/ns/one", "scm-one"),
       location("https://scm.scm-manager.org/repo/ns/two", "scm-two"),
@@ -92,6 +101,10 @@ public class SvnScmInformationResolverTest {
 
   @Test
   public void testResolveWithMultipleLocations() {
+    mockSource(
+      run,
+      "https://scm.scm-manager.org/repo/ns/one",
+      "https://scm.scm-manager.org/repo/ns/two");
     applyLocations(
       location("https://scm.scm-manager.org/repo/ns/one", "scm-one"),
       location("https://scm.scm-manager.org/repo/ns/two", "scm-two")

--- a/src/test/java/com/cloudogu/scmmanager/info/TestJob.java
+++ b/src/test/java/com/cloudogu/scmmanager/info/TestJob.java
@@ -1,0 +1,10 @@
+package com.cloudogu.scmmanager.info;
+
+import hudson.model.ItemGroup;
+import hudson.model.Job;
+
+public abstract class TestJob extends Job<TestJob, TestRun> {
+  protected TestJob(ItemGroup parent, String name) {
+    super(parent, name);
+  }
+}

--- a/src/test/java/com/cloudogu/scmmanager/info/TestRun.java
+++ b/src/test/java/com/cloudogu/scmmanager/info/TestRun.java
@@ -1,0 +1,12 @@
+package com.cloudogu.scmmanager.info;
+
+import hudson.model.Run;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+public abstract class TestRun extends Run<TestJob, TestRun> {
+  protected TestRun(@Nonnull TestJob job) throws IOException {
+    super(job);
+  }
+}

--- a/src/test/java/com/cloudogu/scmmanager/info/TestSCMSourceOwner.java
+++ b/src/test/java/com/cloudogu/scmmanager/info/TestSCMSourceOwner.java
@@ -1,0 +1,15 @@
+package com.cloudogu.scmmanager.info;
+
+import jenkins.model.Jenkins;
+import jenkins.scm.api.SCMSourceOwner;
+import org.jvnet.hudson.reactor.ReactorException;
+
+import javax.servlet.ServletContext;
+import java.io.File;
+import java.io.IOException;
+
+public abstract class TestSCMSourceOwner extends Jenkins implements SCMSourceOwner {
+  protected TestSCMSourceOwner(File root, ServletContext context) throws IOException, InterruptedException, ReactorException {
+    super(root, context);
+  }
+}


### PR DESCRIPTION
With this change, the plugin compares the URLs for checkout events with the configured repository URLs for the build job and only sends build results to the configured SCM-Manager.

Fixes https://issues.jenkins.io/browse/JENKINS-67588

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
