### PR TITLE
Relax uri comparison

### DIFF
--- a/src/main/java/com/cloudogu/scmmanager/info/GitScmInformationResolver.java
+++ b/src/main/java/com/cloudogu/scmmanager/info/GitScmInformationResolver.java
@@ -57,7 +57,7 @@ public class GitScmInformationResolver implements ScmInformationResolver {
     return createInformation(git, revision.get())
       .stream()
       .filter(jobInformation -> {
-        boolean contains = remoteBases.contains(jobInformation.getUrl());
+        boolean contains = remoteBases.contains(URIs.normalize(jobInformation.getUrl()));
         if (!contains) {
           LOG.trace(
             "skip {}, because it is not part of the source owner {}. Maybe it is a library.",

--- a/src/main/java/com/cloudogu/scmmanager/info/HgScmInformationResolver.java
+++ b/src/main/java/com/cloudogu/scmmanager/info/HgScmInformationResolver.java
@@ -55,7 +55,7 @@ public class HgScmInformationResolver implements ScmInformationResolver {
 
     JobInformation config = createInformation(hg, revision, source);
 
-    if (remoteBases.contains(config.getUrl())) {
+    if (remoteBases.contains(URIs.normalize(config.getUrl()))) {
       return Collections.singleton(config);
     }
 

--- a/src/main/java/com/cloudogu/scmmanager/info/SourceUtil.java
+++ b/src/main/java/com/cloudogu/scmmanager/info/SourceUtil.java
@@ -24,7 +24,7 @@ public final class SourceUtil {
           .getSCMSources()
           .stream()
           .filter(scmSource -> canExtract(scmSource, sourceType))
-          .map(scmSource -> extract(scmSource, sourceType, urlExtractor))
+          .map(scmSource -> extractAndNormalize(scmSource, sourceType, urlExtractor))
           .collect(Collectors.toList())
       ).orElse(Collections.emptyList());
   }
@@ -45,6 +45,11 @@ public final class SourceUtil {
 
   private static boolean canExtract(SCMSource scmSource, Class<?> sourceType) {
     return sourceType.isAssignableFrom(scmSource.getClass()) || scmSource instanceof ScmManagerSource;
+  }
+
+  private static <T> String extractAndNormalize(SCMSource scmSource, Class<T> sourceType, Function<T, String> urlExtractor) {
+    String url = extract(scmSource, sourceType, urlExtractor);
+    return URIs.normalize(url);
   }
 
   private static <T> String extract(SCMSource scmSource, Class<T> sourceType, Function<T, String> urlExtractor) {

--- a/src/main/java/com/cloudogu/scmmanager/info/SvnScmInformationResolver.java
+++ b/src/main/java/com/cloudogu/scmmanager/info/SvnScmInformationResolver.java
@@ -61,7 +61,7 @@ public class SvnScmInformationResolver implements ScmInformationResolver {
     return configurations
       .stream()
       .filter(jobInformation -> remoteBases.stream().anyMatch(remoteBase -> {
-        boolean valid = jobInformation.getUrl().startsWith(remoteBase);
+        boolean valid = URIs.normalize(jobInformation.getUrl()).startsWith(remoteBase);
         if (!valid) {
           LOG.trace(
             "skip {}, because it does not start of the source owner {}. Maybe it is a library.",

--- a/src/main/java/com/cloudogu/scmmanager/info/URIs.java
+++ b/src/main/java/com/cloudogu/scmmanager/info/URIs.java
@@ -1,0 +1,27 @@
+package com.cloudogu.scmmanager.info;
+
+import java.net.URI;
+
+final class URIs {
+
+  private URIs() {
+  }
+
+  static String normalize(String value) {
+    URI uri = URI.create(value);
+    String scheme = uri.getScheme();
+    int port = uri.getPort();
+    if (port < 0) {
+      if ("http".equals(scheme)) {
+        port = 80;
+      } else if ("https".equals(scheme)) {
+        port = 443;
+      } else if ("ssh".equals(scheme)) {
+        port = 22;
+      }
+    }
+    return String.format(
+      "%s://%s:%d%s", scheme, uri.getHost(), port, uri.getPath()
+    );
+  }
+}

--- a/src/test/java/com/cloudogu/scmmanager/info/GitScmInformationResolverTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/info/GitScmInformationResolverTest.java
@@ -81,7 +81,7 @@ public class GitScmInformationResolverTest {
     applyRevision("abc42");
     applyUrcs(
       urc("https://scm.scm-manager.org/repo/ns/one", "scm-one"),
-      urc("https://scm.scm-manager.org/repo/ns/two", "scm-two")
+      urc("https://scm.scm-manager.org:443/repo/ns/two", "scm-two")
     );
 
     Collection<JobInformation> information = resolver.resolve(run, git);
@@ -89,7 +89,7 @@ public class GitScmInformationResolverTest {
 
     Iterator<JobInformation> it = information.iterator();
     Assertions.info(it.next(), "git", "abc42", "https://scm.scm-manager.org/repo/ns/one", "scm-one");
-    Assertions.info(it.next(), "git", "abc42", "https://scm.scm-manager.org/repo/ns/two", "scm-two");
+    Assertions.info(it.next(), "git", "abc42", "https://scm.scm-manager.org:443/repo/ns/two", "scm-two");
   }
 
   @Test

--- a/src/test/java/com/cloudogu/scmmanager/info/HgScmInformationResolverTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/info/HgScmInformationResolverTest.java
@@ -57,7 +57,7 @@ public class HgScmInformationResolverTest {
 
   @Test
   public void testResolve() {
-    mockSource(run, "https://scm.scm-manager.org/repo/ns/one");
+    mockSource(run, "https://scm.scm-manager.org:443/repo/ns/one");
     doReturn("https://scm.scm-manager.org/repo/ns/one").when(hg).getSource();
     applyRevision("42abc");
     when(hg.getCredentialsId()).thenReturn("scm-one");

--- a/src/test/java/com/cloudogu/scmmanager/info/SvnScmInformationResolverTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/info/SvnScmInformationResolverTest.java
@@ -116,7 +116,7 @@ public class SvnScmInformationResolverTest {
     mockSource(
       run,
       "https://scm.scm-manager.org/repo/ns/one",
-      "https://scm.scm-manager.org/repo/ns/two");
+      "https://scm.scm-manager.org:443/repo/ns/two");
     applyLocations(
       location("https://scm.scm-manager.org/repo/ns/one", "scm-one"),
       location("https://scm.scm-manager.org/repo/ns/two", "scm-two")

--- a/src/test/java/com/cloudogu/scmmanager/info/URIsTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/info/URIsTest.java
@@ -1,0 +1,57 @@
+package com.cloudogu.scmmanager.info;
+
+import org.assertj.core.api.AbstractBooleanAssert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static com.cloudogu.scmmanager.info.URIs.normalize;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class URIsTest {
+
+  @Test
+  public void shouldNotModifyURI() {
+    String[] uris = new String[]{
+      "http://hitchhiker.com:8080", "http://hitchhiker.com:8080/path",
+      "https://hitchhiker.com:8443", "https://hitchhiker.com:8443/some/path",
+      "http://hitchhiker.com:80", "http://hitchhiker.com:80/path",
+      "http://hitchhiker.com:443", "http://hitchhiker.com:443/path",
+      "ssh://hitchhiker.com:2222","ssh://hitchhiker.com:2222/path",
+      "ssh://hitchhiker.com:22/path","ssh://hitchhiker.com:22/path"
+    };
+
+    for (String uri : uris) {
+      assertThat(normalize(uri)).isEqualTo(uri);
+    }
+  }
+
+  @Test
+  public void shouldAddPort() {
+    assertThat(normalize("http://hitchhiker.com")).isEqualTo("http://hitchhiker.com:80");
+    assertThat(normalize("https://hitchhiker.com")).isEqualTo("https://hitchhiker.com:443");
+    assertThat(normalize("ssh://hitchhiker.com")).isEqualTo("ssh://hitchhiker.com:22");
+    assertThat(normalize("http://hitchhiker.com/path")).isEqualTo("http://hitchhiker.com:80/path");
+    assertThat(normalize("https://hitchhiker.com/path")).isEqualTo("https://hitchhiker.com:443/path");
+    assertThat(normalize("ssh://hitchhiker.com/path")).isEqualTo("ssh://hitchhiker.com:22/path");
+  }
+
+  @Test
+  public void shouldRemoveCredentials() {
+    assertThat(normalize("http://trillian@hitchhiker.com:8080")).isEqualTo("http://hitchhiker.com:8080");
+    assertThat(normalize("http://trillian:secret@hitchhiker.com:8080")).isEqualTo("http://hitchhiker.com:8080");
+  }
+
+  @Test
+  public void shouldRemoveQueryParameters() {
+    assertThat(normalize("http://hitchhiker.com:8080/path?a=b")).isEqualTo("http://hitchhiker.com:8080/path");
+  }
+
+  @Test
+  public void shouldRemoveHashParameters() {
+    assertThat(normalize("http://hitchhiker.com:8080/path#abc")).isEqualTo("http://hitchhiker.com:8080/path");
+  }
+
+}

--- a/src/test/java/com/cloudogu/scmmanager/info/URIsTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/info/URIsTest.java
@@ -1,11 +1,6 @@
 package com.cloudogu.scmmanager.info;
 
-import org.assertj.core.api.AbstractBooleanAssert;
 import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 import static com.cloudogu.scmmanager.info.URIs.normalize;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,6 +37,7 @@ public class URIsTest {
   public void shouldRemoveCredentials() {
     assertThat(normalize("http://trillian@hitchhiker.com:8080")).isEqualTo("http://hitchhiker.com:8080");
     assertThat(normalize("http://trillian:secret@hitchhiker.com:8080")).isEqualTo("http://hitchhiker.com:8080");
+    assertThat(normalize("ssh://trillian@hitchhiker.com/path")).isEqualTo("ssh://hitchhiker.com:22/path");
   }
 
   @Test


### PR DESCRIPTION
Ensure that http, https and ssh urls without port treated as the same if the default port is included in the url.
Credentials, query parameters and hash urls are ignored for the equality check.
This should fix sending of notifications in which the source url does not contain the port, but the scm url contains a default port.

[JENKINS-67588](https://issues.jenkins.io/browse/JENKINS-67588)

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
