### PR TITLE
JENKINS-68472: Add jaxb plugin dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
       <version>1.0.5</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>jaxb</artifactId>
+      <version>2.3.0.1</version>
+    </dependency>
+
     <!-- scm plugins should be optional -->
 
     <dependency>


### PR DESCRIPTION
Fixes [JENKINS-68472](https://issues.jenkins.io/browse/JENKINS-68472)

Add jaxb plugin dependency to use jaxb after it was removed from the Jenkins core.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
