### PR TITLE
Prevent Jenkins from removing repositories

### DIFF
--- a/src/main/java/com/cloudogu/scmmanager/scm/ScmManagerNavigator.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/ScmManagerNavigator.java
@@ -140,12 +140,15 @@ public class ScmManagerNavigator extends SCMNavigator {
             subProjectName = repository.getName();
           }
           if (request.process(subProjectName, new ScmManagerSourceFactory(request, repository), null, new NavigatorWitness(listener))) {
-            // the observer has seen enough and doesn't want to see any more
+            // the observer has seen enough and doesn't want to see anymore
             return;
           }
         }
       } catch (ExecutionException e) {
         ExecutionExceptions.log(e);
+        // We have to throw an IOException here to prevent Jenkins
+        // from removing all previously found repositories
+        throw new IOException("failed to load repositories from SCM-Manager", e);
       }
     }
   }

--- a/src/test/java/com/cloudogu/scmmanager/scm/ScmManagerNavigatorTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/scm/ScmManagerNavigatorTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -161,6 +162,20 @@ public class ScmManagerNavigatorTest {
 
     SCMSource source = sourceCaptor.getValue();
     assertThat(source).isInstanceOf(ScmManagerSource.class);
+  }
+
+  @Test(expected = IOException.class)
+  public void shouldThrowIOExceptionOnError() throws IOException, InterruptedException, ExecutionException {
+    mockApiResponse(
+      repository("git", "heart-of-gold")
+    );
+
+    CompletableFuture<List<Repository>> repositoryRequest = mock(CompletableFuture.class);
+    when(api.getRepositories(NAMESPACE)).thenReturn(repositoryRequest);
+    when(repositoryRequest.get()).thenThrow(new ExecutionException("test", null));
+
+    ScmManagerNavigator navigator = navigator("git");
+    navigator.visitSources(observer);
   }
 
   @NonNull


### PR DESCRIPTION
If SCM-Manager is not available, Jenkins will remove all
repositories in organization folders for this SCM-Manager
instance if it is scanned (either periodically or manually).
To prevent this, an exception has to be thrown in the
navigator to indicate, that the scan did not perform
as expected.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
