### PR TITLE
Fix 'exclude branch build' flag

### DIFF
--- a/src/main/java/com/cloudogu/scmmanager/scm/ScmManagerSource.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/ScmManagerSource.java
@@ -127,7 +127,8 @@ public class ScmManagerSource extends SCMSource {
     ScmManagerSourceRetriever handler = ScmManagerSourceRetriever.create(
       createApi(),
       namespace,
-      name
+      name,
+      traits
     );
 
     // for now we trigger a full scan for deletions
@@ -153,7 +154,7 @@ public class ScmManagerSource extends SCMSource {
   @NonNull
   @Override
   protected SCMProbe createProbe(@NonNull SCMHead head, @CheckForNull SCMRevision revision) {
-    ScmManagerSourceRetriever handler = ScmManagerSourceRetriever.create(createApi(), namespace, name);
+    ScmManagerSourceRetriever handler = ScmManagerSourceRetriever.create(createApi(), namespace, name, traits);
     return handler.probe(head, revision);
   }
 

--- a/src/test/java/com/cloudogu/scmmanager/scm/ScmManagerSourceRetrieverTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/scm/ScmManagerSourceRetrieverTest.java
@@ -13,6 +13,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -34,7 +35,7 @@ public class ScmManagerSourceRetrieverTest {
       CompletableFuture.completedFuture(new Repository(NAMESPACE, NAME, "git"))
     );
 
-    handler = ScmManagerSourceRetriever.create(api, NAMESPACE, NAME);
+    handler = ScmManagerSourceRetriever.create(api, NAMESPACE, NAME, Collections.emptyList());
   }
 
   @Test


### PR DESCRIPTION
Should ignore all branch build trigger for branches which should not be build anymore because related pull requests exists and therefore the branch builds should be excluded.
