### PR TITLE
Migrate to okhttp for Java 11 support

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,6 @@
-buildPlugin()
+buildPlugin(
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 17],
+    [platform: 'windows', jdk: 11],
+])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 17],
+    [platform: 'linux', jdk: 11],
     [platform: 'windows', jdk: 11],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,6 @@ buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
     [platform: 'linux', jdk: 11],
+    [platform: 'linux', jdk: 17],
     [platform: 'windows', jdk: 11],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,5 @@ buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
     [platform: 'linux', jdk: 11],
-    [platform: 'linux', jdk: 17],
     [platform: 'windows', jdk: 11],
 ])

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,308 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.2.0
+#
+# Required ENV vars:
+# ------------------
+#   JAVA_HOME - location of a JDK home dir
+#
+# Optional ENV vars
+# -----------------
+#   MAVEN_OPTS - parameters passed to the Java VM when running Maven
+#     e.g. to debug Maven itself, use
+#       set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+#   MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+# ----------------------------------------------------------------------------
+
+if [ -z "$MAVEN_SKIP_RC" ] ; then
+
+  if [ -f /usr/local/etc/mavenrc ] ; then
+    . /usr/local/etc/mavenrc
+  fi
+
+  if [ -f /etc/mavenrc ] ; then
+    . /etc/mavenrc
+  fi
+
+  if [ -f "$HOME/.mavenrc" ] ; then
+    . "$HOME/.mavenrc"
+  fi
+
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+mingw=false
+case "$(uname)" in
+  CYGWIN*) cygwin=true ;;
+  MINGW*) mingw=true;;
+  Darwin*) darwin=true
+    # Use /usr/libexec/java_home if available, otherwise fall back to /Library/Java/Home
+    # See https://developer.apple.com/library/mac/qa/qa1170/_index.html
+    if [ -z "$JAVA_HOME" ]; then
+      if [ -x "/usr/libexec/java_home" ]; then
+        JAVA_HOME="$(/usr/libexec/java_home)"; export JAVA_HOME
+      else
+        JAVA_HOME="/Library/Java/Home"; export JAVA_HOME
+      fi
+    fi
+    ;;
+esac
+
+if [ -z "$JAVA_HOME" ] ; then
+  if [ -r /etc/gentoo-release ] ; then
+    JAVA_HOME=$(java-config --jre-home)
+  fi
+fi
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin ; then
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=$(cygpath --unix "$JAVA_HOME")
+  [ -n "$CLASSPATH" ] &&
+    CLASSPATH=$(cygpath --path --unix "$CLASSPATH")
+fi
+
+# For Mingw, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$JAVA_HOME" ] && [ -d "$JAVA_HOME" ] &&
+    JAVA_HOME="$(cd "$JAVA_HOME" || (echo "cannot cd into $JAVA_HOME."; exit 1); pwd)"
+fi
+
+if [ -z "$JAVA_HOME" ]; then
+  javaExecutable="$(which javac)"
+  if [ -n "$javaExecutable" ] && ! [ "$(expr "\"$javaExecutable\"" : '\([^ ]*\)')" = "no" ]; then
+    # readlink(1) is not available as standard on Solaris 10.
+    readLink=$(which readlink)
+    if [ ! "$(expr "$readLink" : '\([^ ]*\)')" = "no" ]; then
+      if $darwin ; then
+        javaHome="$(dirname "\"$javaExecutable\"")"
+        javaExecutable="$(cd "\"$javaHome\"" && pwd -P)/javac"
+      else
+        javaExecutable="$(readlink -f "\"$javaExecutable\"")"
+      fi
+      javaHome="$(dirname "\"$javaExecutable\"")"
+      javaHome=$(expr "$javaHome" : '\(.*\)/bin')
+      JAVA_HOME="$javaHome"
+      export JAVA_HOME
+    fi
+  fi
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD="$(\unset -f command 2>/dev/null; \command -v java)"
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly." >&2
+  echo "  We cannot execute $JAVACMD" >&2
+  exit 1
+fi
+
+if [ -z "$JAVA_HOME" ] ; then
+  echo "Warning: JAVA_HOME environment variable is not set."
+fi
+
+# traverses directory structure from process work directory to filesystem root
+# first directory with .mvn subdirectory is considered project base directory
+find_maven_basedir() {
+  if [ -z "$1" ]
+  then
+    echo "Path not specified to find_maven_basedir"
+    return 1
+  fi
+
+  basedir="$1"
+  wdir="$1"
+  while [ "$wdir" != '/' ] ; do
+    if [ -d "$wdir"/.mvn ] ; then
+      basedir=$wdir
+      break
+    fi
+    # workaround for JBEAP-8937 (on Solaris 10/Sparc)
+    if [ -d "${wdir}" ]; then
+      wdir=$(cd "$wdir/.." || exit 1; pwd)
+    fi
+    # end of workaround
+  done
+  printf '%s' "$(cd "$basedir" || exit 1; pwd)"
+}
+
+# concatenates all lines of a file
+concat_lines() {
+  if [ -f "$1" ]; then
+    # Remove \r in case we run on Windows within Git Bash
+    # and check out the repository with auto CRLF management
+    # enabled. Otherwise, we may read lines that are delimited with
+    # \r\n and produce $'-Xarg\r' rather than -Xarg due to word
+    # splitting rules.
+    tr -s '\r\n' ' ' < "$1"
+  fi
+}
+
+log() {
+  if [ "$MVNW_VERBOSE" = true ]; then
+    printf '%s\n' "$1"
+  fi
+}
+
+BASE_DIR=$(find_maven_basedir "$(dirname "$0")")
+if [ -z "$BASE_DIR" ]; then
+  exit 1;
+fi
+
+MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$BASE_DIR"}; export MAVEN_PROJECTBASEDIR
+log "$MAVEN_PROJECTBASEDIR"
+
+##########################################################################################
+# Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
+# This allows using the maven wrapper in projects that prohibit checking in binary data.
+##########################################################################################
+wrapperJarPath="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar"
+if [ -r "$wrapperJarPath" ]; then
+    log "Found $wrapperJarPath"
+else
+    log "Couldn't find $wrapperJarPath, downloading it ..."
+
+    if [ -n "$MVNW_REPOURL" ]; then
+      wrapperUrl="$MVNW_REPOURL/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+    else
+      wrapperUrl="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+    fi
+    while IFS="=" read -r key value; do
+      # Remove '\r' from value to allow usage on windows as IFS does not consider '\r' as a separator ( considers space, tab, new line ('\n'), and custom '=' )
+      safeValue=$(echo "$value" | tr -d '\r')
+      case "$key" in (wrapperUrl) wrapperUrl="$safeValue"; break ;;
+      esac
+    done < "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
+    log "Downloading from: $wrapperUrl"
+
+    if $cygwin; then
+      wrapperJarPath=$(cygpath --path --windows "$wrapperJarPath")
+    fi
+
+    if command -v wget > /dev/null; then
+        log "Found wget ... using wget"
+        [ "$MVNW_VERBOSE" = true ] && QUIET="" || QUIET="--quiet"
+        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+            wget $QUIET "$wrapperUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
+        else
+            wget $QUIET --http-user="$MVNW_USERNAME" --http-password="$MVNW_PASSWORD" "$wrapperUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
+        fi
+    elif command -v curl > /dev/null; then
+        log "Found curl ... using curl"
+        [ "$MVNW_VERBOSE" = true ] && QUIET="" || QUIET="--silent"
+        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+            curl $QUIET -o "$wrapperJarPath" "$wrapperUrl" -f -L || rm -f "$wrapperJarPath"
+        else
+            curl $QUIET --user "$MVNW_USERNAME:$MVNW_PASSWORD" -o "$wrapperJarPath" "$wrapperUrl" -f -L || rm -f "$wrapperJarPath"
+        fi
+    else
+        log "Falling back to using Java to download"
+        javaSource="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/MavenWrapperDownloader.java"
+        javaClass="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/MavenWrapperDownloader.class"
+        # For Cygwin, switch paths to Windows format before running javac
+        if $cygwin; then
+          javaSource=$(cygpath --path --windows "$javaSource")
+          javaClass=$(cygpath --path --windows "$javaClass")
+        fi
+        if [ -e "$javaSource" ]; then
+            if [ ! -e "$javaClass" ]; then
+                log " - Compiling MavenWrapperDownloader.java ..."
+                ("$JAVA_HOME/bin/javac" "$javaSource")
+            fi
+            if [ -e "$javaClass" ]; then
+                log " - Running MavenWrapperDownloader.java ..."
+                ("$JAVA_HOME/bin/java" -cp .mvn/wrapper MavenWrapperDownloader "$wrapperUrl" "$wrapperJarPath") || rm -f "$wrapperJarPath"
+            fi
+        fi
+    fi
+fi
+##########################################################################################
+# End of extension
+##########################################################################################
+
+# If specified, validate the SHA-256 sum of the Maven wrapper jar file
+wrapperSha256Sum=""
+while IFS="=" read -r key value; do
+  case "$key" in (wrapperSha256Sum) wrapperSha256Sum=$value; break ;;
+  esac
+done < "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
+if [ -n "$wrapperSha256Sum" ]; then
+  wrapperSha256Result=false
+  if command -v sha256sum > /dev/null; then
+    if echo "$wrapperSha256Sum  $wrapperJarPath" | sha256sum -c > /dev/null 2>&1; then
+      wrapperSha256Result=true
+    fi
+  elif command -v shasum > /dev/null; then
+    if echo "$wrapperSha256Sum  $wrapperJarPath" | shasum -a 256 -c > /dev/null 2>&1; then
+      wrapperSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available."
+    echo "Please install either command, or disable validation by removing 'wrapperSha256Sum' from your maven-wrapper.properties."
+    exit 1
+  fi
+  if [ $wrapperSha256Result = false ]; then
+    echo "Error: Failed to validate Maven wrapper SHA-256, your Maven wrapper might be compromised." >&2
+    echo "Investigate or delete $wrapperJarPath to attempt a clean download." >&2
+    echo "If you updated your Maven version, you need to update the specified wrapperSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+MAVEN_OPTS="$(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config") $MAVEN_OPTS"
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=$(cygpath --path --windows "$JAVA_HOME")
+  [ -n "$CLASSPATH" ] &&
+    CLASSPATH=$(cygpath --path --windows "$CLASSPATH")
+  [ -n "$MAVEN_PROJECTBASEDIR" ] &&
+    MAVEN_PROJECTBASEDIR=$(cygpath --path --windows "$MAVEN_PROJECTBASEDIR")
+fi
+
+# Provide a "standardized" way to retrieve the CLI args that will
+# work with both Windows and non-Windows executions.
+MAVEN_CMD_LINE_ARGS="$MAVEN_CONFIG $*"
+export MAVEN_CMD_LINE_ARGS
+
+WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+# shellcheck disable=SC2086 # safe args
+exec "$JAVACMD" \
+  $MAVEN_OPTS \
+  $MAVEN_DEBUG_OPTS \
+  -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
+  "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
+  ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,205 @@
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.2.0
+@REM
+@REM Required ENV vars:
+@REM JAVA_HOME - location of a JDK home dir
+@REM
+@REM Optional ENV vars
+@REM MAVEN_BATCH_ECHO - set to 'on' to enable the echoing of the batch commands
+@REM MAVEN_BATCH_PAUSE - set to 'on' to wait for a keystroke before ending
+@REM MAVEN_OPTS - parameters passed to the Java VM when running Maven
+@REM     e.g. to debug Maven itself, use
+@REM set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+@REM MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+@REM ----------------------------------------------------------------------------
+
+@REM Begin all REM lines with '@' in case MAVEN_BATCH_ECHO is 'on'
+@echo off
+@REM set title of command window
+title %0
+@REM enable echoing by setting MAVEN_BATCH_ECHO to 'on'
+@if "%MAVEN_BATCH_ECHO%" == "on"  echo %MAVEN_BATCH_ECHO%
+
+@REM set %HOME% to equivalent of $HOME
+if "%HOME%" == "" (set "HOME=%HOMEDRIVE%%HOMEPATH%")
+
+@REM Execute a user defined script before this one
+if not "%MAVEN_SKIP_RC%" == "" goto skipRcPre
+@REM check for pre script, once with legacy .bat ending and once with .cmd ending
+if exist "%USERPROFILE%\mavenrc_pre.bat" call "%USERPROFILE%\mavenrc_pre.bat" %*
+if exist "%USERPROFILE%\mavenrc_pre.cmd" call "%USERPROFILE%\mavenrc_pre.cmd" %*
+:skipRcPre
+
+@setlocal
+
+set ERROR_CODE=0
+
+@REM To isolate internal variables from possible post scripts, we use another setlocal
+@setlocal
+
+@REM ==== START VALIDATION ====
+if not "%JAVA_HOME%" == "" goto OkJHome
+
+echo.
+echo Error: JAVA_HOME not found in your environment. >&2
+echo Please set the JAVA_HOME variable in your environment to match the >&2
+echo location of your Java installation. >&2
+echo.
+goto error
+
+:OkJHome
+if exist "%JAVA_HOME%\bin\java.exe" goto init
+
+echo.
+echo Error: JAVA_HOME is set to an invalid directory. >&2
+echo JAVA_HOME = "%JAVA_HOME%" >&2
+echo Please set the JAVA_HOME variable in your environment to match the >&2
+echo location of your Java installation. >&2
+echo.
+goto error
+
+@REM ==== END VALIDATION ====
+
+:init
+
+@REM Find the project base dir, i.e. the directory that contains the folder ".mvn".
+@REM Fallback to current working directory if not found.
+
+set MAVEN_PROJECTBASEDIR=%MAVEN_BASEDIR%
+IF NOT "%MAVEN_PROJECTBASEDIR%"=="" goto endDetectBaseDir
+
+set EXEC_DIR=%CD%
+set WDIR=%EXEC_DIR%
+:findBaseDir
+IF EXIST "%WDIR%"\.mvn goto baseDirFound
+cd ..
+IF "%WDIR%"=="%CD%" goto baseDirNotFound
+set WDIR=%CD%
+goto findBaseDir
+
+:baseDirFound
+set MAVEN_PROJECTBASEDIR=%WDIR%
+cd "%EXEC_DIR%"
+goto endDetectBaseDir
+
+:baseDirNotFound
+set MAVEN_PROJECTBASEDIR=%EXEC_DIR%
+cd "%EXEC_DIR%"
+
+:endDetectBaseDir
+
+IF NOT EXIST "%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config" goto endReadAdditionalConfig
+
+@setlocal EnableExtensions EnableDelayedExpansion
+for /F "usebackq delims=" %%a in ("%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config") do set JVM_CONFIG_MAVEN_PROPS=!JVM_CONFIG_MAVEN_PROPS! %%a
+@endlocal & set JVM_CONFIG_MAVEN_PROPS=%JVM_CONFIG_MAVEN_PROPS%
+
+:endReadAdditionalConfig
+
+SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
+set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
+set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+set WRAPPER_URL="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+
+FOR /F "usebackq tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+    IF "%%A"=="wrapperUrl" SET WRAPPER_URL=%%B
+)
+
+@REM Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
+@REM This allows using the maven wrapper in projects that prohibit checking in binary data.
+if exist %WRAPPER_JAR% (
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Found %WRAPPER_JAR%
+    )
+) else (
+    if not "%MVNW_REPOURL%" == "" (
+        SET WRAPPER_URL="%MVNW_REPOURL%/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+    )
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Couldn't find %WRAPPER_JAR%, downloading it ...
+        echo Downloading from: %WRAPPER_URL%
+    )
+
+    powershell -Command "&{"^
+		"$webclient = new-object System.Net.WebClient;"^
+		"if (-not ([string]::IsNullOrEmpty('%MVNW_USERNAME%') -and [string]::IsNullOrEmpty('%MVNW_PASSWORD%'))) {"^
+		"$webclient.Credentials = new-object System.Net.NetworkCredential('%MVNW_USERNAME%', '%MVNW_PASSWORD%');"^
+		"}"^
+		"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $webclient.DownloadFile('%WRAPPER_URL%', '%WRAPPER_JAR%')"^
+		"}"
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Finished downloading %WRAPPER_JAR%
+    )
+)
+@REM End of extension
+
+@REM If specified, validate the SHA-256 sum of the Maven wrapper jar file
+SET WRAPPER_SHA_256_SUM=""
+FOR /F "usebackq tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+    IF "%%A"=="wrapperSha256Sum" SET WRAPPER_SHA_256_SUM=%%B
+)
+IF NOT %WRAPPER_SHA_256_SUM%=="" (
+    powershell -Command "&{"^
+       "$hash = (Get-FileHash \"%WRAPPER_JAR%\" -Algorithm SHA256).Hash.ToLower();"^
+       "If('%WRAPPER_SHA_256_SUM%' -ne $hash){"^
+       "  Write-Output 'Error: Failed to validate Maven wrapper SHA-256, your Maven wrapper might be compromised.';"^
+       "  Write-Output 'Investigate or delete %WRAPPER_JAR% to attempt a clean download.';"^
+       "  Write-Output 'If you updated your Maven version, you need to update the specified wrapperSha256Sum property.';"^
+       "  exit 1;"^
+       "}"^
+       "}"
+    if ERRORLEVEL 1 goto error
+)
+
+@REM Provide a "standardized" way to retrieve the CLI args that will
+@REM work with both Windows and non-Windows executions.
+set MAVEN_CMD_LINE_ARGS=%*
+
+%MAVEN_JAVA_EXE% ^
+  %JVM_CONFIG_MAVEN_PROPS% ^
+  %MAVEN_OPTS% ^
+  %MAVEN_DEBUG_OPTS% ^
+  -classpath %WRAPPER_JAR% ^
+  "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" ^
+  %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*
+if ERRORLEVEL 1 goto error
+goto end
+
+:error
+set ERROR_CODE=1
+
+:end
+@endlocal & set ERROR_CODE=%ERROR_CODE%
+
+if not "%MAVEN_SKIP_RC%"=="" goto skipRcPost
+@REM check for post script, once with legacy .bat ending and once with .cmd ending
+if exist "%USERPROFILE%\mavenrc_post.bat" call "%USERPROFILE%\mavenrc_post.bat"
+if exist "%USERPROFILE%\mavenrc_post.cmd" call "%USERPROFILE%\mavenrc_post.cmd"
+:skipRcPost
+
+@REM pause the script if MAVEN_BATCH_PAUSE is set to 'on'
+if "%MAVEN_BATCH_PAUSE%"=="on" pause
+
+if "%MAVEN_TERMINATE_CMD%"=="on" exit %ERROR_CODE%
+
+cmd /C exit /B %ERROR_CODE%

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,13 @@
     </dependency>
 
     <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <version>4.11.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>trilead-api</artifactId>
       <version>2.84.v72119de229b_7</version>
@@ -150,13 +157,6 @@
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
       <version>2.10</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock</artifactId>
-      <version>3.0.0-beta-8</version>
-      <scope>test</scope>
     </dependency>
 
     <!-- fix require upper bound dependencies errors for slf4j -->
@@ -324,11 +324,6 @@
         <version>3.8.1</version>
         <scope>test</scope>
       </dependency>
-
-<!--      <dependency>-->
-<!--        <groupId></groupId>-->
-<!--        <artifactId>jett</artifactId>-->
-<!--      </dependency>-->
 
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.43</version>
+    <version>4.66</version>
     <relativePath />
   </parent>
 
@@ -20,9 +20,9 @@
 
   <properties>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>2.263.3</jenkins.version>
+    <jenkins.version>2.387.1</jenkins.version>
     <slf4j.version>1.7.30</slf4j.version>
-    <java.level>8</java.level>
+    <java.level>11</java.level>
     <!-- Other properties you may want to use:
       ~ jenkins-test-harness.version: Jenkins Test Harness version you use to test the plugin. For Jenkins version >= 1.580.1 use JTH 2.0 or higher.
       ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
@@ -43,37 +43,37 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.20</version>
+      <version>324.va_f5d6774f3a_d</version>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.3.11</version>
+      <version>1189.vf61b_a_5e2f62e</version>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-credentials</artifactId>
-      <version>1.17.4</version>
+      <version>305.v8f4381501156</version>
     </dependency>
 
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>async-http-client</artifactId>
-      <version>1.9.40.0</version>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>okhttp-api</artifactId>
+      <version>4.11.0-145.vcb_8de402ef81</version>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>trilead-api</artifactId>
-      <version>1.0.5</version>
+      <version>2.84.v72119de229b_7</version>
     </dependency>
 
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>jaxb</artifactId>
-      <version>2.3.0.1</version>
+      <version>2.3.8-1</version>
     </dependency>
 
     <!-- scm plugins should be optional -->
@@ -81,29 +81,35 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>3.5.0</version>
+      <version>5.0.2</version>
       <optional>true</optional>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>subversion</artifactId>
-      <version>2.12.2</version>
+      <version>2.17.2</version>
       <optional>true</optional>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mercurial</artifactId>
-      <version>2.11</version>
+      <version>1260.vdfb_723cdcc81</version>
       <optional>true</optional>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>branch-api</artifactId>
-      <version>2.0.11</version>
+      <version>2.1105.v472604208c55</version>
       <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>cloudbees-folder</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -114,9 +120,16 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-support</artifactId>
+      <version>839.v35e2736cfd5c</version>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
-      <version>2.10.0</version>
+      <version>2.15.2-350.v0c2f3f8fc595</version>
     </dependency>
 
     <dependency>
@@ -141,8 +154,8 @@
 
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
-      <version>2.23.2</version>
+      <artifactId>wiremock</artifactId>
+      <version>2.27.2</version>
       <scope>test</scope>
     </dependency>
 
@@ -184,7 +197,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>job-dsl</artifactId>
-      <version>1.77</version>
+      <version>1.84</version>
       <optional>true</optional>
     </dependency>
 
@@ -198,7 +211,7 @@
       <dependency>
         <groupId>org.jenkins-ci</groupId>
         <artifactId>annotation-indexer</artifactId>
-        <version>1.12</version>
+        <version>1.16</version>
       </dependency>
 
       <dependency>
@@ -210,55 +223,97 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-scm-step</artifactId>
-        <version>2.6</version>
+        <version>408.v7d5b_135a_b_d49</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-support</artifactId>
+        <version>839.v35e2736cfd5c</version>
       </dependency>
 
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-step-api</artifactId>
-        <version>2.22</version>
+        <version>639.v6eca_cd8c04a_a_</version>
       </dependency>
 
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-api</artifactId>
-        <version>2.40</version>
+        <version>1213.v646def1087f9</version>
       </dependency>
 
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>junit</artifactId>
-        <version>1.29</version>
+        <version>1207.va_09d5100410f</version>
       </dependency>
 
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>scm-api</artifactId>
-        <version>2.6.3</version>
+        <version>672.v64378a_b_20c60</version>
       </dependency>
 
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.10.0</version>
+        <version>2.15.2</version>
       </dependency>
 
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.10.0</version>
+        <version>2.15.2</version>
       </dependency>
 
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>script-security</artifactId>
-        <version>1.71</version>
+        <version>1251.vfe552ed55f8d</version>
       </dependency>
 
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>matrix-project</artifactId>
-        <version>1.17</version>
+        <version>789.v57a_725b_63c79</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>javax-activation-api</artifactId>
+        <version>1.2.0-6</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin-util</artifactId>
+        <version>789.v57a_725b_63c79</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>display-url-api</artifactId>
+        <version>2.3.7</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>cloudbees-folder</artifactId>
+        <version>6.815.v0dd5a_cb_40e0e</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jenkins.plugins</groupId>
+            <artifactId>ionicons-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jenkins.plugins</groupId>
+        <artifactId>ionicons-api</artifactId>
+        <version>45.vf54fca_5d2154</version>
       </dependency>
 
       <!-- fix require upper bound dependencies error for wiremock -->
@@ -270,12 +325,10 @@
         <scope>test</scope>
       </dependency>
 
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-security</artifactId>
-        <version>9.4.15.v20190215</version>
-        <scope>test</scope>
-      </dependency>
+<!--      <dependency>-->
+<!--        <groupId></groupId>-->
+<!--        <artifactId>jett</artifactId>-->
+<!--      </dependency>-->
 
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>junit</artifactId>
-        <version>1207.va_09d5100410f</version>
+        <version>1189.v1b_e593637fa_e</version>
       </dependency>
 
       <dependency>
@@ -278,6 +278,12 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>matrix-project</artifactId>
         <version>789.v57a_725b_63c79</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>font-awesome-api</artifactId>
+        <version>6.2.0-3</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -391,7 +391,7 @@
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.7.9</version>
+            <version>0.8.10</version>
             <executions>
               <execution>
                 <phase>initialize</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock</artifactId>
-      <version>2.27.2</version>
+      <version>3.0.0-beta-8</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/com/cloudogu/scmmanager/BasicHttpAuthentication.java
+++ b/src/main/java/com/cloudogu/scmmanager/BasicHttpAuthentication.java
@@ -2,9 +2,9 @@ package com.cloudogu.scmmanager;
 
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import com.google.common.annotations.VisibleForTesting;
-import com.ning.http.client.AsyncHttpClient;
-import com.ning.http.client.Realm;
 import hudson.util.Secret;
+import okhttp3.Credentials;
+import okhttp3.Request;
 
 public class BasicHttpAuthentication implements HttpAuthentication {
 
@@ -30,13 +30,7 @@ public class BasicHttpAuthentication implements HttpAuthentication {
     return password;
   }
 
-  public void authenticate(AsyncHttpClient.BoundRequestBuilder requestBuilder) {
-    Realm realm = new Realm.RealmBuilder()
-      .setUsePreemptiveAuth(true)
-      .setScheme(Realm.AuthScheme.BASIC)
-      .setPrincipal(username)
-      .setPassword(password.getPlainText())
-      .build();
-    requestBuilder.setRealm(realm);
+  public void authenticate(Request.Builder requestBuilder) {
+    requestBuilder.header("Authorization", Credentials.basic(username, password.getPlainText()));
   }
 }

--- a/src/main/java/com/cloudogu/scmmanager/BearerHttpAuthentication.java
+++ b/src/main/java/com/cloudogu/scmmanager/BearerHttpAuthentication.java
@@ -1,6 +1,6 @@
 package com.cloudogu.scmmanager;
 
-import com.ning.http.client.AsyncHttpClient;
+import okhttp3.Request;
 
 public class BearerHttpAuthentication implements HttpAuthentication {
 
@@ -11,11 +11,11 @@ public class BearerHttpAuthentication implements HttpAuthentication {
   }
 
   @Override
-  public void authenticate(AsyncHttpClient.BoundRequestBuilder requestBuilder) {
+  public void authenticate(Request.Builder requestBuilder) {
     authenticate(requestBuilder, accessToken);
   }
 
-  public static void authenticate(AsyncHttpClient.BoundRequestBuilder requestBuilder, String accessToken) {
+  public static void authenticate(Request.Builder requestBuilder, String accessToken) {
     requestBuilder.addHeader("Authorization", "Bearer ".concat(accessToken));
   }
 }

--- a/src/main/java/com/cloudogu/scmmanager/HttpAuthentication.java
+++ b/src/main/java/com/cloudogu/scmmanager/HttpAuthentication.java
@@ -1,9 +1,9 @@
 package com.cloudogu.scmmanager;
 
-import com.ning.http.client.AsyncHttpClient;
+import okhttp3.Request;
 
 public interface HttpAuthentication {
 
-  void authenticate(AsyncHttpClient.BoundRequestBuilder requestBuilder);
+  void authenticate(Request.Builder requestBuilder);
 
 }

--- a/src/main/java/com/cloudogu/scmmanager/ScmMigratedV1Notifier.java
+++ b/src/main/java/com/cloudogu/scmmanager/ScmMigratedV1Notifier.java
@@ -41,7 +41,7 @@ public class ScmMigratedV1Notifier implements Notifier {
     if (client != null) {
       return client;
     }
-    return JenkinsOkHttpClient.newClientBuilder(new OkHttpClient()).build();
+    return JenkinsOkHttpClient.newClientBuilder(new OkHttpClient.Builder().followRedirects(false).build()).build();
   }
 
   @VisibleForTesting
@@ -58,11 +58,9 @@ public class ScmMigratedV1Notifier implements Notifier {
 
   @Override
   public void notify(String revision, BuildStatus buildStatus) {
-    Request.Builder request = new Request.Builder().url(information.getUrl())
-      .get();
-    // TODO not follow redirects
+    Request.Builder request = new Request.Builder().url(information.getUrl()).get();
     authenticationFactory.createHttp(run, information.getCredentialsId()).authenticate(request);
-    client.newCall(request.build()).enqueue(new Callback() {
+    getClient().newCall(request.build()).enqueue(new Callback() {
 
       @Override
       public void onResponse(Call call, Response response) throws IOException {

--- a/src/main/java/com/cloudogu/scmmanager/scm/api/ApiClient.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/api/ApiClient.java
@@ -7,6 +7,7 @@ import okhttp3.Callback;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
@@ -44,8 +45,13 @@ public abstract class ApiClient {
       public void onResponse(Call call, Response response) {
         if (response.code() == 200) {
           try {
-            T t = objectMapper.readValue(response.body().bytes(), type);
-            future.complete(t);
+            ResponseBody body = response.body();
+            if (body == null) {
+              future.complete(null);
+            } else {
+              T t = objectMapper.readValue(body.bytes(), type);
+              future.complete(t);
+            }
           } catch (Exception ex) {
             future.completeExceptionally(ex);
           }

--- a/src/main/java/com/cloudogu/scmmanager/scm/api/ApiClient.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/api/ApiClient.java
@@ -2,10 +2,13 @@ package com.cloudogu.scmmanager.scm.api;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ning.http.client.AsyncCompletionHandler;
-import com.ning.http.client.AsyncHttpClient;
-import com.ning.http.client.Response;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 
+import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
 public abstract class ApiClient {
@@ -29,27 +32,26 @@ public abstract class ApiClient {
 
   public abstract String getBaseUrl();
 
-  protected <T> CompletableFuture<T> execute(AsyncHttpClient.BoundRequestBuilder requestBuilder, Class<T> type) {
+  protected <T> CompletableFuture<T> execute(OkHttpClient client, Request.Builder requestBuilder, Class<T> type) {
     CompletableFuture<T> future = new CompletableFuture<>();
-    requestBuilder.execute(new AsyncCompletionHandler<Response>() {
+    client.newCall(requestBuilder.build()).enqueue(new Callback() {
       @Override
-      public void onThrowable(Throwable ex) {
+      public void onFailure(Call call, IOException ex) {
         future.completeExceptionally(ex);
       }
 
       @Override
-      public Response onCompleted(Response response) {
-        if (response.getStatusCode() == 200) {
+      public void onResponse(Call call, Response response) {
+        if (response.code() == 200) {
           try {
-            T t = objectMapper.readValue(response.getResponseBodyAsBytes(), type);
+            T t = objectMapper.readValue(response.body().bytes(), type);
             future.complete(t);
           } catch (Exception ex) {
             future.completeExceptionally(ex);
           }
         } else {
-          future.completeExceptionally(new IllegalReturnStatusException(response.getStatusCode()));
+          future.completeExceptionally(new IllegalReturnStatusException(response.code()));
         }
-        return response;
       }
     });
 

--- a/src/main/java/com/cloudogu/scmmanager/scm/api/SshApiClient.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/api/SshApiClient.java
@@ -39,12 +39,12 @@ public class SshApiClient extends ApiClient {
   private final SSHAuthentication authentication;
 
   public SshApiClient(String sshUrl, SSHAuthentication authentication) {
-    this(new OkHttpClient(), new SshConnectionFactory(), sshUrl, authentication);
+    this(JenkinsOkHttpClient.newClientBuilder(new OkHttpClient()).build(), new SshConnectionFactory(), sshUrl, authentication);
   }
 
   public SshApiClient(OkHttpClient client, SshConnectionFactory connectionFactory, String sshUrl, SSHAuthentication authentication) {
     super("ssh");
-    this.client = JenkinsOkHttpClient.newClientBuilder(client).build();
+    this.client = client;
     this.connectionFactory = connectionFactory;
     this.sshUrl = sshUrl;
     this.authentication = authentication;

--- a/src/test/java/com/cloudogu/scmmanager/BasicHttpAuthenticationTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/BasicHttpAuthenticationTest.java
@@ -24,7 +24,7 @@ public class BasicHttpAuthenticationTest {
     BasicHttpAuthentication authenticator = new BasicHttpAuthentication("trillian", secret);
     authenticator.authenticate(requestBuilder);
 
-    verify(requestBuilder).header("trillian", "{}");
+    verify(requestBuilder).header("Authorization", "Basic dHJpbGxpYW46e30=");
   }
 
 }

--- a/src/test/java/com/cloudogu/scmmanager/BasicHttpAuthenticationTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/BasicHttpAuthenticationTest.java
@@ -1,26 +1,19 @@
 package com.cloudogu.scmmanager;
 
-import com.ning.http.client.AsyncHttpClient;
-import com.ning.http.client.Realm;
 import hudson.util.Secret;
+import okhttp3.Request;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BasicHttpAuthenticationTest {
 
   @Mock
-  private AsyncHttpClient.BoundRequestBuilder requestBuilder;
-
-  @Captor
-  private ArgumentCaptor<Realm> realmCaptor;
+  private Request.Builder requestBuilder;
 
   @Test
   public void testAuthenticate() {
@@ -31,11 +24,7 @@ public class BasicHttpAuthenticationTest {
     BasicHttpAuthentication authenticator = new BasicHttpAuthentication("trillian", secret);
     authenticator.authenticate(requestBuilder);
 
-    verify(requestBuilder).setRealm(realmCaptor.capture());
-
-    Realm realm = realmCaptor.getValue();
-    assertEquals("trillian", realm.getPrincipal());
-    assertEquals("{}", realm.getPassword());
+    verify(requestBuilder).header("trillian", "{}");
   }
 
 }

--- a/src/test/java/com/cloudogu/scmmanager/BearerHttpAuthenticationTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/BearerHttpAuthenticationTest.java
@@ -1,6 +1,6 @@
 package com.cloudogu.scmmanager;
 
-import com.ning.http.client.AsyncHttpClient;
+import okhttp3.Request;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.verify;
 public class BearerHttpAuthenticationTest {
 
   @Mock
-  private AsyncHttpClient.BoundRequestBuilder requestBuilder;
+  private Request.Builder requestBuilder;
 
   @Test
   public void shouldAppendBearerHeader() {

--- a/src/test/java/com/cloudogu/scmmanager/RecordedRequestDispatcher.java
+++ b/src/test/java/com/cloudogu/scmmanager/RecordedRequestDispatcher.java
@@ -1,0 +1,64 @@
+package com.cloudogu.scmmanager;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.util.Arrays;
+
+/**
+ * This uses json mapping files from the resources (src/test/resources/mappings) and
+ * answers requests with responses stored there.
+ * These files had been created using wiremock on the first run.
+ */
+public class RecordedRequestDispatcher extends Dispatcher {
+  private final File mappings = new File(getClass().getClassLoader().getResource("mappings").getFile());
+
+  @Override
+  public MockResponse dispatch(RecordedRequest request) {
+    String requestedPath = request.getPath();
+    return Arrays.stream(mappings.listFiles())
+      .filter(
+        file -> {
+          try {
+            JsonObject mapping = JsonParser.parseReader(new FileReader(file)).getAsJsonObject();
+            JsonObject recordedRequest = mapping.get("request").getAsJsonObject();
+            JsonElement acceptNode = recordedRequest.get("headers").getAsJsonObject().get("Accept");
+            return requestedPath.endsWith(recordedRequest.get("url").getAsString())
+              && (acceptNode == null || acceptNode.getAsJsonObject().get("equalTo").getAsString().equals(request.getHeader("Accept")));
+          } catch (FileNotFoundException e) {
+            throw new RuntimeException("failed to read mapping " + file, e);
+          }
+        }
+      )
+      .map(
+        file -> {
+          try {
+            JsonObject mapping = JsonParser.parseReader(new FileReader(file)).getAsJsonObject();
+            JsonObject recordedResponse = mapping.get("response").getAsJsonObject();
+            MockResponse mockResponse = new MockResponse()
+              .setResponseCode(recordedResponse.get("status").getAsInt())
+              .setBody(recordedResponse.get("body").getAsString());
+            JsonObject headers = recordedResponse.get("headers").getAsJsonObject();
+            headers.keySet().forEach(
+              h -> mockResponse.setHeader(h, headers.get(h).getAsString())
+            );
+            return mockResponse;
+          } catch (FileNotFoundException e) {
+            throw new RuntimeException("failed to read mapping " + file, e);
+          }
+        }
+      )
+      .findFirst()
+      .orElseGet(() -> {
+        System.out.println("no response found for request path " + request.getPath());
+        return new MockResponse().setResponseCode(404);
+      });
+  }
+}

--- a/src/test/java/com/cloudogu/scmmanager/ScmMigratedV1NotifierTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/ScmMigratedV1NotifierTest.java
@@ -2,8 +2,8 @@ package com.cloudogu.scmmanager;
 
 import com.cloudogu.scmmanager.info.JobInformation;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.ning.http.client.AsyncHttpClient;
 import hudson.model.Run;
+import okhttp3.OkHttpClient;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,7 +45,7 @@ public class ScmMigratedV1NotifierTest {
   @Before
   public void prepareAuthentication() {
     when(authenticationFactory.createHttp(run, "one"))
-      .thenReturn(response -> response.setHeader("Auth", "Awesome"));
+      .thenReturn(response -> response.header("Auth", "Awesome"));
   }
 
   @Test
@@ -57,12 +57,11 @@ public class ScmMigratedV1NotifierTest {
     ScmMigratedV1Notifier notifier = createV1Notifier();
     AtomicReference<JobInformation> reference = applyV2Notifier(cdl, null);
 
-    try (AsyncHttpClient client = new AsyncHttpClient()) {
-      notifier.setClient(client);
-      notifier.notify("abc123", BuildStatus.success("old-repo", "Old-Repo", "https://oss.cloudogu.com"));
+    OkHttpClient client = new OkHttpClient();
+    notifier.setClient(client);
+    notifier.notify("abc123", BuildStatus.success("old-repo", "Old-Repo", "https://oss.cloudogu.com"));
 
-      cdl.await(30, TimeUnit.SECONDS);
-    }
+    cdl.await(30, TimeUnit.SECONDS);
 
     assertInfo(reference);
   }
@@ -80,12 +79,11 @@ public class ScmMigratedV1NotifierTest {
 
     BuildStatus success = BuildStatus.success("old-repo", "Old-Repo",  "https://oss.cloudogu.com");
 
-    try (AsyncHttpClient client = new AsyncHttpClient()) {
-      notifier.setClient(client);
-      notifier.notify("abc123", success);
+    OkHttpClient client = new OkHttpClient();
+    notifier.setClient(client);
+    notifier.notify("abc123", success);
 
-      cdl.await(30, TimeUnit.SECONDS);
-    }
+    cdl.await(30, TimeUnit.SECONDS);
 
     assertInfo(reference);
     Mockito.verify(v2Notifier).notify("abc123", success);

--- a/src/test/java/com/cloudogu/scmmanager/ScmV2NotifierTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/ScmV2NotifierTest.java
@@ -1,8 +1,11 @@
 package com.cloudogu.scmmanager;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import okhttp3.OkHttpClient;
-import org.junit.Rule;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -11,77 +14,46 @@ import java.net.URL;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
-import static com.github.tomakehurst.wiremock.client.WireMock.put;
-import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ScmV2NotifierTest {
 
-  @Rule
-  public WireMockRule wireMockRule = new WireMockRule(0);
+  private final MockWebServer server = new MockWebServer();
 
   @Test
   public void testNotifyForChangesets() throws IOException, InterruptedException {
     testNotify("/scm/api/v2/ci/ns/one/changesets/abc/jenkins/hitchhiker%2Fheart-of-gold", "hitchhiker/heart-of-gold", null);
 
-    verify(
-      putRequestedFor(urlMatching("/scm/api/v2/ci/ns/one/changesets/abc/jenkins/hitchhiker%2Fheart-of-gold"))
-        .withHeader("Authenticated", equalTo("yes; awesome"))
-        .withHeader("Content-Type", equalTo("application/vnd.scmm-cistatus+json;v=2"))
-        .withRequestBody(
-          matchingJsonPath("$.type", equalTo("jenkins"))
-        )
-        .withRequestBody(
-          matchingJsonPath("$.name", equalTo("hitchhiker/heart-of-gold"))
-        )
-        .withRequestBody(
-          matchingJsonPath("$.url", equalTo("https://hitchhiker.com"))
-        )
-        .withRequestBody(
-          matchingJsonPath("$.status", equalTo("SUCCESS"))
-        )
-    );
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getRequestUrl().encodedPath()).isEqualTo("/scm/api/v2/ci/ns/one/changesets/abc/jenkins/hitchhiker%2Fheart-of-gold");
+    assertThat(request.getHeader("Authenticated")).isEqualTo("yes; awesome");
+    assertThat(request.getHeader("Content-Type")).isEqualTo("application/vnd.scmm-cistatus+json;v=2");
+    JsonObject jsonElement = JsonParser.parseString(request.getBody().readUtf8()).getAsJsonObject();
+    assertThat(jsonElement.get("type").getAsString()).isEqualTo("jenkins");
+    assertThat(jsonElement.get("name").getAsString()).isEqualTo("hitchhiker/heart-of-gold");
+    assertThat(jsonElement.get("url").getAsString()).isEqualTo("https://hitchhiker.com");
+    assertThat(jsonElement.get("status").getAsString()).isEqualTo("SUCCESS");
   }
 
   @Test
   public void testNotifyForPullRequests() throws IOException, InterruptedException {
     testNotify("/scm/api/v2/ci/ns/one/pullrequest/abc/jenkins/hitchhiker%2Fpr-1", "hitchhiker/heart-of-gold", "hitchhiker/pr-1");
 
-    verify(
-      putRequestedFor(urlMatching("/scm/api/v2/ci/ns/one/pullrequest/abc/jenkins/hitchhiker%2Fpr-1"))
-        .withHeader("Authenticated", equalTo("yes; awesome"))
-        .withHeader("Content-Type", equalTo("application/vnd.scmm-cistatus+json;v=2"))
-        .withRequestBody(
-          matchingJsonPath("$.type", equalTo("jenkins"))
-        )
-        .withRequestBody(
-          matchingJsonPath("$.name", equalTo("hitchhiker/pr-1"))
-        )
-        .withRequestBody(
-          matchingJsonPath("$.url", equalTo("https://hitchhiker.com"))
-        )
-        .withRequestBody(
-          matchingJsonPath("$.status", equalTo("SUCCESS"))
-        )
-        .withRequestBody(
-          matchingJsonPath("$.replaces", equalTo("hitchhiker/hitchhiker%2Fheart-of-gold"))
-        )
-    );
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getRequestUrl().encodedPath()).isEqualTo("/scm/api/v2/ci/ns/one/pullrequest/abc/jenkins/hitchhiker%2Fpr-1");
+    assertThat(request.getHeader("Authenticated")).isEqualTo("yes; awesome");
+    assertThat(request.getHeader("Content-Type")).isEqualTo("application/vnd.scmm-cistatus+json;v=2");
+    JsonObject jsonElement = JsonParser.parseString(request.getBody().readUtf8()).getAsJsonObject();
+    assertThat(jsonElement.get("type").getAsString()).isEqualTo("jenkins");
+    assertThat(jsonElement.get("name").getAsString()).isEqualTo("hitchhiker/pr-1");
+    assertThat(jsonElement.get("url").getAsString()).isEqualTo("https://hitchhiker.com");
+    assertThat(jsonElement.get("status").getAsString()).isEqualTo("SUCCESS");
+    assertThat(jsonElement.get("replaces").getAsString()).isEqualTo("hitchhiker/hitchhiker%2Fheart-of-gold");
   }
 
   private void testNotify(String notificationUrl, String branch, String pullRequest) throws IOException, InterruptedException {
-    stubFor(
-      put(notificationUrl)
-        .willReturn(
-          aResponse()
-            .withStatus(200)
-        )
-    );
+    server.enqueue(new MockResponse().setResponseCode(200));
+    server.start();
 
     URL instanceURL = createInstanceURL();
     NamespaceAndName namespaceAndName = new NamespaceAndName("ns", "one");
@@ -110,6 +82,6 @@ public class ScmV2NotifierTest {
   }
 
   private URL createInstanceURL() throws MalformedURLException {
-    return new URL("http", "localhost", wireMockRule.port(), "/scm");
+    return new URL("http", "localhost", server.getPort(), "/scm");
   }
 }

--- a/src/test/java/com/cloudogu/scmmanager/scm/ScmManagerSourceDescriptorTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/scm/ScmManagerSourceDescriptorTest.java
@@ -4,7 +4,6 @@ import com.cloudogu.scmmanager.scm.api.IllegalReturnStatusException;
 import com.cloudogu.scmmanager.scm.api.Repository;
 import com.cloudogu.scmmanager.scm.api.ScmManagerApi;
 import com.cloudogu.scmmanager.scm.api.ScmManagerApiFactory;
-import com.github.tomakehurst.wiremock.admin.NotFoundException;
 import de.otto.edison.hal.HalRepresentation;
 import de.otto.edison.hal.Link;
 import de.otto.edison.hal.Links;
@@ -137,7 +136,7 @@ public class ScmManagerSourceDescriptorTest {
 
   @Test
   public void shouldRejectServerUrlThatCouldNotBeFound() throws InterruptedException, ExecutionException {
-    ScmManagerApiTestMocks.mockError(new NotFoundException("not found"), when(api.index()));
+    ScmManagerApiTestMocks.mockError(new RuntimeException("not found"), when(api.index()));
 
     FormValidation formValidation = descriptor.doCheckServerUrl("http://example.com");
 
@@ -215,7 +214,7 @@ public class ScmManagerSourceDescriptorTest {
 
   @Test
   public void shouldReturnEmptyListOnError() throws InterruptedException, ExecutionException {
-    ScmManagerApiTestMocks.mockError(new NotFoundException("not found"), when(api.getRepositories()));
+    ScmManagerApiTestMocks.mockError(new RuntimeException("not found"), when(api.getRepositories()));
 
     ListBoxModel model = descriptor.fillRepositoryItems(scmSourceOwner, "http://example.com", "myAuth", null);
 

--- a/src/test/java/com/cloudogu/scmmanager/scm/api/ApiClientTestBase.java
+++ b/src/test/java/com/cloudogu/scmmanager/scm/api/ApiClientTestBase.java
@@ -1,16 +1,24 @@
 package com.cloudogu.scmmanager.scm.api;
 
 import com.cloudogu.scmmanager.HttpAuthentication;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Before;
-import org.junit.Rule;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Arrays;
 
 public class ApiClientTestBase {
-  @Rule
-  public WireMockRule rule = new WireMockRule(options().dynamicPort());
+
+  private final MockWebServer server = new MockWebServer();
 
   private OkHttpClient client;
 
@@ -18,8 +26,12 @@ public class ApiClientTestBase {
   private int pathInjectionIndex = 0;
 
   @Before
-  public void setUpAHC() {
-    this.client = new OkHttpClient();
+  public void setUpServerAndClient() throws IOException {
+    client = new OkHttpClient();
+
+    Dispatcher mDispatcher = new RecordedRequestDispatcher();
+    server.setDispatcher(mDispatcher);
+    server.start();
   }
 
   public OkHttpClient getClient() {
@@ -27,16 +39,13 @@ public class ApiClientTestBase {
   }
 
   protected ApiClient apiClient() {
-    HttpAuthentication noAuthentication = requestBuilder -> {};
+    HttpAuthentication noAuthentication = requestBuilder -> {
+    };
     return new HttpApiClient(client, noAuthentication, this::serverUrl);
   }
 
-  protected void injectPath(String... pathInjection) {
-    this.pathInjection = pathInjection;
-  }
-
   protected String serverUrl(String path) {
-    return String.format("http://localhost:%d%s", rule.port(), nextPathInjection() + path);
+    return String.format("http://localhost:%d%s", server.getPort(), nextPathInjection() + path);
   }
 
   private String nextPathInjection() {
@@ -47,5 +56,52 @@ public class ApiClientTestBase {
       return pathInjection[0];
     }
     return pathInjection[pathInjectionIndex++];
+  }
+
+  /**
+   * This uses json mapping files from the resources (src/test/resources/mappings) and
+   * answers requests with responses stored there.
+   * These files had been created using wiremock on the first run.
+   */
+  private static class RecordedRequestDispatcher extends Dispatcher {
+    private final File mappings = new File(getClass().getClassLoader().getResource("mappings").getFile());
+
+    @Override
+    public MockResponse dispatch(RecordedRequest request) {
+      String requestedPath = request.getPath();
+      return Arrays.stream(mappings.listFiles())
+        .filter(
+          file -> {
+            try {
+              JsonObject mapping = JsonParser.parseReader(new FileReader(file)).getAsJsonObject();
+              JsonObject recoredRequest = mapping.get("request").getAsJsonObject();
+              return requestedPath.endsWith(recoredRequest.get("url").getAsString())
+                && recoredRequest.get("headers").getAsJsonObject().get("Accept").getAsJsonObject().get("equalTo").getAsString().equals(request.getHeader("Accept"));
+            } catch (FileNotFoundException e) {
+              throw new RuntimeException("failed to read mapping " + file, e);
+            }
+          }
+        )
+        .map(
+          file -> {
+            try {
+              JsonObject mapping = JsonParser.parseReader(new FileReader(file)).getAsJsonObject();
+              JsonObject recordedResponse = mapping.get("response").getAsJsonObject();
+              MockResponse mockResponse = new MockResponse()
+                .setResponseCode(recordedResponse.get("status").getAsInt())
+                .setBody(recordedResponse.get("body").getAsString());
+              JsonObject headers = recordedResponse.get("headers").getAsJsonObject();
+              headers.keySet().forEach(
+                h -> mockResponse.setHeader(h, headers.get(h).getAsString())
+              );
+              return mockResponse;
+            } catch (FileNotFoundException e) {
+              throw new RuntimeException("failed to read mapping " + file, e);
+            }
+          }
+        )
+        .findFirst()
+        .orElseGet(() -> new MockResponse().setResponseCode(404));
+    }
   }
 }

--- a/src/test/java/com/cloudogu/scmmanager/scm/api/ApiClientTestBase.java
+++ b/src/test/java/com/cloudogu/scmmanager/scm/api/ApiClientTestBase.java
@@ -2,8 +2,7 @@ package com.cloudogu.scmmanager.scm.api;
 
 import com.cloudogu.scmmanager.HttpAuthentication;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.ning.http.client.AsyncHttpClient;
-import org.junit.After;
+import okhttp3.OkHttpClient;
 import org.junit.Before;
 import org.junit.Rule;
 
@@ -13,22 +12,17 @@ public class ApiClientTestBase {
   @Rule
   public WireMockRule rule = new WireMockRule(options().dynamicPort());
 
-  private AsyncHttpClient client;
+  private OkHttpClient client;
 
   private String[] pathInjection = {};
   private int pathInjectionIndex = 0;
 
   @Before
   public void setUpAHC() {
-    this.client = new AsyncHttpClient();
+    this.client = new OkHttpClient();
   }
 
-  @After
-  public void tearDownAHC() {
-    this.client.close();
-  }
-
-  public AsyncHttpClient getClient() {
+  public OkHttpClient getClient() {
     return client;
   }
 

--- a/src/test/java/com/cloudogu/scmmanager/scm/api/ApiClientTestBase.java
+++ b/src/test/java/com/cloudogu/scmmanager/scm/api/ApiClientTestBase.java
@@ -1,20 +1,13 @@
 package com.cloudogu.scmmanager.scm.api;
 
 import com.cloudogu.scmmanager.HttpAuthentication;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.cloudogu.scmmanager.RecordedRequestDispatcher;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.Dispatcher;
-import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Before;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
-import java.util.Arrays;
 
 public class ApiClientTestBase {
 
@@ -58,50 +51,4 @@ public class ApiClientTestBase {
     return pathInjection[pathInjectionIndex++];
   }
 
-  /**
-   * This uses json mapping files from the resources (src/test/resources/mappings) and
-   * answers requests with responses stored there.
-   * These files had been created using wiremock on the first run.
-   */
-  private static class RecordedRequestDispatcher extends Dispatcher {
-    private final File mappings = new File(getClass().getClassLoader().getResource("mappings").getFile());
-
-    @Override
-    public MockResponse dispatch(RecordedRequest request) {
-      String requestedPath = request.getPath();
-      return Arrays.stream(mappings.listFiles())
-        .filter(
-          file -> {
-            try {
-              JsonObject mapping = JsonParser.parseReader(new FileReader(file)).getAsJsonObject();
-              JsonObject recoredRequest = mapping.get("request").getAsJsonObject();
-              return requestedPath.endsWith(recoredRequest.get("url").getAsString())
-                && recoredRequest.get("headers").getAsJsonObject().get("Accept").getAsJsonObject().get("equalTo").getAsString().equals(request.getHeader("Accept"));
-            } catch (FileNotFoundException e) {
-              throw new RuntimeException("failed to read mapping " + file, e);
-            }
-          }
-        )
-        .map(
-          file -> {
-            try {
-              JsonObject mapping = JsonParser.parseReader(new FileReader(file)).getAsJsonObject();
-              JsonObject recordedResponse = mapping.get("response").getAsJsonObject();
-              MockResponse mockResponse = new MockResponse()
-                .setResponseCode(recordedResponse.get("status").getAsInt())
-                .setBody(recordedResponse.get("body").getAsString());
-              JsonObject headers = recordedResponse.get("headers").getAsJsonObject();
-              headers.keySet().forEach(
-                h -> mockResponse.setHeader(h, headers.get(h).getAsString())
-              );
-              return mockResponse;
-            } catch (FileNotFoundException e) {
-              throw new RuntimeException("failed to read mapping " + file, e);
-            }
-          }
-        )
-        .findFirst()
-        .orElseGet(() -> new MockResponse().setResponseCode(404));
-    }
-  }
 }

--- a/src/test/java/com/cloudogu/scmmanager/scm/api/SshApiClientTest.java
+++ b/src/test/java/com/cloudogu/scmmanager/scm/api/SshApiClientTest.java
@@ -4,7 +4,6 @@ import com.cloudogu.scmmanager.SSHAuthentication;
 import com.cloudogu.scmmanager.SshConnection;
 import com.cloudogu.scmmanager.SshConnectionFactory;
 import com.cloudogu.scmmanager.SshConnectionFailedException;
-import com.ning.http.client.AsyncHttpClient;
 import de.otto.edison.hal.Link;
 import de.otto.edison.hal.Links;
 import org.junit.Test;

--- a/src/test/resources/mappings/oldRepoRedirect.json
+++ b/src/test/resources/mappings/oldRepoRedirect.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "url": "/scm/git/some/old/repo",
+    "method": "GET",
+    "headers": {
+      "Auth": {
+        "equalTo": "Awesome"
+      }
+    }
+  },
+  "response": {
+    "status": 301,
+    "body": "",
+    "headers": {
+      "Location": "https://localhost/scm/old/repo"
+    }
+  }
+}


### PR DESCRIPTION
Replace old async http library with okhttp for java
11 support. This also sets a new minor version for
jenkins.