### PR TITLE
Disable automatic redirect to detect CAS login page

### DIFF
--- a/src/main/java/com/cloudogu/scmmanager/OkHttpClientBuilder.java
+++ b/src/main/java/com/cloudogu/scmmanager/OkHttpClientBuilder.java
@@ -32,6 +32,7 @@ public final class OkHttpClientBuilder {
             LOG.warn("SCM-Manager request failed", ioe);
           }
         })
+        .followRedirects(false)
         .build();
   }
 }


### PR DESCRIPTION
With the change from async-http-client to okhttp we got an automatic redirect for SCM API requests. These redirects had been used to detect forwards to the CAS login page before. To make this possible again, this disables the automatic redirects in the okhttp client.
