### PR TITLE
Close response body of http connection

### DIFF
--- a/src/main/java/com/cloudogu/scmmanager/scm/api/ApiClient.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/api/ApiClient.java
@@ -44,8 +44,7 @@ public abstract class ApiClient {
       @Override
       public void onResponse(Call call, Response response) {
         if (response.code() == 200) {
-          try {
-            ResponseBody body = response.body();
+          try (ResponseBody body = response.body()) {
             if (body == null) {
               future.complete(null);
             } else {


### PR DESCRIPTION
Closing the body is necessary in okhttp, because the body is
backed by the socket. Without this, we get exceptions like
the following:

```
Apr 12, 2024 1:08:10 AM WARNING okhttp3.internal.platform.Platform log
A connection to https://atlas002.cloud.itz.in.bund.de/ was leaked. Did you forget to close a response body?
java.lang.Throwable: response.body().close()
at okhttp3.internal.platform.Platform.getStackTraceForCloseable(Platform.kt:145)
at okhttp3.internal.connection.RealCall.callStart(RealCall.kt:170)
at okhttp3.internal.connection.RealCall.enqueue(RealCall.kt:163)
at com.cloudogu.scmmanager.scm.api.ApiClient.execute(ApiClient.java:38)
at com.cloudogu.scmmanager.scm.api.HttpApiClient.get(HttpApiClient.java:60)
at com.cloudogu.scmmanager.scm.api.ScmManagerApi.getFileObject(ScmManagerApi.java:217)
```