### PR TITLE
Close responses to avoid leaked connections

### DIFF
--- a/src/main/java/com/cloudogu/scmmanager/ScmMigratedV1Notifier.java
+++ b/src/main/java/com/cloudogu/scmmanager/ScmMigratedV1Notifier.java
@@ -64,15 +64,17 @@ public class ScmMigratedV1Notifier implements Notifier {
 
       @Override
       public void onResponse(Call call, Response response) throws IOException {
-        if (response.isRedirect()) {
-          String location = response.header("Location");
-          if (!Strings.isNullOrEmpty(location)) {
-            notifyV2(location, revision, buildStatus);
+        try (response) {
+          if (response.isRedirect()) {
+            String location = response.header("Location");
+            if (!Strings.isNullOrEmpty(location)) {
+              notifyV2(location, revision, buildStatus);
+            } else {
+              LOG.warn("server returned redirect without location header");
+            }
           } else {
-            LOG.warn("server returned redirect without location header");
+            LOG.debug("expected redirect, but server returned status code {}", response.code());
           }
-        } else {
-          LOG.debug("expected redirect, but server returned status code {}", response.code());
         }
       }
 

--- a/src/main/java/com/cloudogu/scmmanager/ScmV2Notifier.java
+++ b/src/main/java/com/cloudogu/scmmanager/ScmV2Notifier.java
@@ -1,7 +1,6 @@
 package com.cloudogu.scmmanager;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.jenkins.plugins.okhttp.api.JenkinsOkHttpClient;
 import net.sf.json.JSONObject;
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -101,12 +100,14 @@ public class ScmV2Notifier implements Notifier {
         }
 
         @Override
-        public void onResponse(Call call, Response response) throws IOException {
-          LOG.info(
-            "status notify for repository {} and revision {} returned {}",
-            namespaceAndName, revision, response.code()
-          );
-          completionListener.accept(response);
+        public void onResponse(Call call, Response response) {
+          try (response) {
+            LOG.info(
+              "status notify for repository {} and revision {} returned {}",
+              namespaceAndName, revision, response.code()
+            );
+            completionListener.accept(response);
+          }
         }
       });
   }

--- a/src/main/java/com/cloudogu/scmmanager/scm/api/ApiClient.java
+++ b/src/main/java/com/cloudogu/scmmanager/scm/api/ApiClient.java
@@ -43,19 +43,21 @@ public abstract class ApiClient {
 
       @Override
       public void onResponse(Call call, Response response) {
-        if (response.code() == 200) {
-          try (ResponseBody body = response.body()) {
-            if (body == null) {
-              future.complete(null);
-            } else {
-              T t = objectMapper.readValue(body.bytes(), type);
-              future.complete(t);
+        try (response) {
+          if (response.code() == 200) {
+            try (ResponseBody body = response.body()) {
+              if (body == null) {
+                future.complete(null);
+              } else {
+                T t = objectMapper.readValue(body.bytes(), type);
+                future.complete(t);
+              }
+            } catch (Exception ex) {
+              future.completeExceptionally(ex);
             }
-          } catch (Exception ex) {
-            future.completeExceptionally(ex);
+          } else {
+            future.completeExceptionally(new IllegalReturnStatusException(response.code()));
           }
-        } else {
-          future.completeExceptionally(new IllegalReturnStatusException(response.code()));
         }
       }
     });


### PR DESCRIPTION
As it seems, only closing the body of a request is not sufficient.
With this, we close all responses we get from requests.
Doing so, I have not gotten any leaked connection error in my setup.